### PR TITLE
bug fix on old ch command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,8 @@ install-dot: backup-existing ## Install dot files to home directory
 	echo "$(GREEN)    ✓$(NC) Successfully installed $(DEST_MODULES_DIR)/.caddie_git"
 	cp "$(SRC_MODULES_DIR)/dot_caddie_github" "$(DEST_MODULES_DIR)/.caddie_github"
 	echo "$(GREEN)    ✓$(NC) Successfully installed $(DEST_MODULES_DIR)/.caddie_github"
+	cp "$(SRC_MODULES_DIR)/dot_caddie_swift" "$(DEST_MODULES_DIR)/.caddie_swift"
+	echo "$(GREEN)    ✓$(NC) Successfully installed $(DEST_MODULES_DIR)/.caddie_swift"
 	cp "$(SRC_MODULES_DIR)/dot_caddie_cli" "$(DEST_MODULES_DIR)/.caddie_cli"
 	echo "$(GREEN)    ✓$(NC) Successfully installed $(DEST_MODULES_DIR)/.caddie_cli"
 	cp "$(SRC_MODULES_DIR)/dot_caddie_debug" "$(DEST_MODULES_DIR)/.caddie_debug"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ shortcuts to make your coding experience smooth and efficient.
 - **Modular Architecture**: Pick and choose the tools you need
 - **Python Management**: Virtual environments, package management, and project scaffolding
 - **Rust Development**: Cargo integration, toolchain management, project templates, and git integration
+- **Swift Development**: Swift Package Manager workflows, formatting, and linting helpers
 - **Ruby Environment**: RVM integration and gem management
 - **JavaScript/Node.js**: NVM integration and package management
 - **iOS Development**: Xcode integration and development tools

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,23 @@
 # Caddie.sh Release Notes
 
+## Version 4.0.0 - Swift Module & Shell Cleanup
+
+**Release Date:** February 2025
+
+### ✨ New Features
+
+- **Swift Module**: Added a first-class Swift Package Manager module mirroring the Rust workflow (`swift:init`, `swift:build`, `swift:run`, `swift:test`, package management, formatting, linting, and gitignore helpers).
+
+### 🐛 Bug Fixes
+
+- **Shell Color Functions**: Replaced legacy `ch-cli` calls in `dot_bashrc` with the modern `caddie cli:*` helpers so git branch selectors and other utilities no longer reference missing commands.
+
+### 📝 Upgrade Notes
+
+- Run `make install-dot` (or reinstall) to deploy `.caddie_swift` into `~/.caddie_modules` and then `caddie reload` to pick up the new module/aliases.
+
+---
+
 ## Version 3.9.5 - Tab Completion Hook Restoration
 
 **Release Date:** February 2025

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -10,6 +10,7 @@ This directory contains detailed documentation for each Caddie.sh module.
 ### Language Modules
 - **[Python Module](python.md)** - Python environment and package management
 - **[Rust Module](rust.md)** - Rust development tools and project management
+- **[Swift Module](swift.md)** - Swift Package Manager workflows
 - **[Ruby Module](ruby.md)** - Ruby environment with RVM integration
 - **[JavaScript Module](javascript.md)** - Node.js and npm management
 

--- a/docs/modules/swift.md
+++ b/docs/modules/swift.md
@@ -1,0 +1,64 @@
+# Swift Module
+
+The Swift module mirrors the Rust workflow but for Swift Package Manager projects. It keeps SwiftPM tasks consistent across the team and bundles common formatting/linting helpers.
+
+## Overview
+
+- **Project Management** – `swift:init`, `swift:build`, `swift:run`, and `swift:test`.
+- **Package Utilities** – Resolve/update/clean/describe dependency graphs.
+- **Code Quality** – `swift:format` (swift-format) and `swift:lint` (SwiftLint).
+- **Git Hygiene** – Generate a Swift-focused `.gitignore`.
+
+## Commands
+
+### `caddie swift:init <name> [--type executable|library]`
+
+Scaffolds a Swift package and writes a `.gitignore`. Example:
+
+```bash
+caddie swift:init short-game --type library
+cd short-game && caddie swift:build
+```
+
+### `caddie swift:build [args]`
+
+Runs `swift build`, forwarding extra flags (e.g., `--configuration release`).
+
+### `caddie swift:run [args]` / `caddie swift:run:tool <target>`
+
+Execute the default executable or a named target with additional arguments.
+
+### `caddie swift:test [args]` / `caddie swift:test:filter <pattern>`
+
+Wraps `swift test`, optionally filtering to `TestCase/testMethod`.
+
+### `caddie swift:package:resolve|update|clean|describe`
+
+Direct wrappers around `swift package` subcommands for dependency management.
+
+### `caddie swift:format [--lint]`
+
+Invokes `swift-format` (if installed). Default formats Sources/Tests in place; `--lint` runs read-only checks.
+
+### `caddie swift:lint`
+
+Runs `swiftlint` with any extra flags you pass.
+
+### `caddie swift:gitignore`
+
+Writes a Swift/Xcode-friendly `.gitignore` containing `.build`, `DerivedData`, `.swiftpm`, and IDE metadata.
+
+### `caddie swift:help`
+
+Prints a concise command reference.
+
+## Requirements
+
+- Xcode or the Swift command line tools (`swift` CLI must exist).
+- Optional: `swift-format` and `swiftlint` (Homebrew installs recommended).
+
+## Troubleshooting
+
+- **"Swift toolchain not found"** – run `xcode-select --install` or install Xcode.
+- **`swift-format` / `swiftlint` missing** – install via `brew install swift-format swiftlint`.
+- **Not a Swift package** – ensure you run commands in a directory containing `Package.swift`.

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -128,7 +128,7 @@ function git_set_branch_from_list() {
   fi
 
   if [[ ${selection} -gt ${branch_count} ]]; then
-    ch-cli red 'Enter a valid number from the list'
+    caddie cli:red 'Enter a valid number from the list'
     return 1
   fi
 
@@ -350,7 +350,7 @@ export -f take
 #       endcap="${installed_version}"
 #     fi
 # 
-#     ch-cli $color "$(ch-marker-rpad "${g}" '.' 40) ${endcap}"
+#     caddie cli:$color "$(ch-marker-rpad "${g}" '.' 40) ${endcap}"
 #   done
 # }
 
@@ -494,7 +494,7 @@ function gb() {
     fi
 
     if [[ "$branch" == "$current_branch" ]]; then
-      ch-cli green "* ${output}"
+      caddie cli:green "* ${output}"
     else
       echo -e "  $output"
     fi

--- a/dot_caddie
+++ b/dot_caddie
@@ -783,6 +783,9 @@ function _caddie_load_modules() {
                       ios)
                         caddie_completion_register "$module_name" "ios:build ios:run ios:test ios:archive ios:pods:install ios:swift:version ios:rust:setup"
                         ;;
+                      swift)
+                        caddie_completion_register "$module_name" "swift:init swift:build swift:run swift:run:tool swift:test swift:test:filter swift:package:resolve swift:package:update swift:package:clean swift:package:describe swift:format swift:lint swift:gitignore"
+                        ;;
                       core)
                         caddie_completion_register "$module_name" "core:status core:set:home core:set:app core:get:app core:help core:aliases core:alias:grep core:alias:git core:alias:docker core:alias:npm core:alias:nav core:lint core:lint:limit"
                         ;;

--- a/dot_caddie_version
+++ b/dot_caddie_version
@@ -4,7 +4,7 @@
 source "$HOME/.caddie_modules/.caddie_cli"
 
 # Private version variable
-CADDIE_SH_VERSION="3.9.5"
+CADDIE_SH_VERSION="4.0.0"
 
 # Function to get the current version
 function caddie_version_get() {

--- a/modules/dot_caddie_swift
+++ b/modules/dot_caddie_swift
@@ -41,7 +41,10 @@ function caddie_swift_init() {
         shift 2 || true
     fi
     caddie cli:title "Creating Swift package '$name' (type: $type)..."
-    mkdir "$name"
+    if ! mkdir "$name"; then
+        caddie cli:red "Failed to create directory '$name'"
+        return 1
+    fi
     (
         cd "$name" && swift package init --name "$name" --type "$type"
     )

--- a/modules/dot_caddie_swift
+++ b/modules/dot_caddie_swift
@@ -42,6 +42,11 @@ function caddie_swift_init() {
     fi
     caddie cli:title "Creating Swift package '$name' (type: $type)..."
     swift package init --name "$name" --type "$type"
+    local status=$?
+    if [ $status -ne 0 ]; then
+        caddie cli:red "swift package init failed (exit $status)"
+        return $status
+    fi
     cat > "$name/.gitignore" <<'GIT'
 /.build
 /DerivedData

--- a/modules/dot_caddie_swift
+++ b/modules/dot_caddie_swift
@@ -41,7 +41,10 @@ function caddie_swift_init() {
         shift 2 || true
     fi
     caddie cli:title "Creating Swift package '$name' (type: $type)..."
-    swift package init --name "$name" --type "$type"
+    mkdir "$name"
+    (
+        cd "$name" && swift package init --name "$name" --type "$type"
+    )
     local status=$?
     if [ $status -ne 0 ]; then
         caddie cli:red "swift package init failed (exit $status)"

--- a/modules/dot_caddie_swift
+++ b/modules/dot_caddie_swift
@@ -1,0 +1,231 @@
+#!/bin/bash
+
+# Caddie.sh - Swift Package Manager helpers
+
+source "$HOME/.caddie_modules/.caddie_cli"
+
+function caddie_swift_require_toolchain() {
+    if ! command -v swift >/dev/null 2>&1; then
+        caddie cli:red "Error: Swift toolchain not found"
+        caddie cli:thought "Install Xcode or the command line tools via xcode-select --install"
+        return 1
+    fi
+    return 0
+}
+
+function caddie_swift_require_package() {
+    caddie_swift_require_toolchain || return 1
+    if [ ! -f "Package.swift" ]; then
+        caddie cli:red "Error: Not inside a Swift Package (Package.swift missing)"
+        return 1
+    fi
+    return 0
+}
+
+function caddie_swift_init() {
+    caddie_swift_require_toolchain || return 1
+    local name="$1"
+    shift || true
+    if [ -z "$name" ]; then
+        caddie cli:red "Error: Please provide a package name"
+        caddie cli:usage "caddie swift:init <name> [--type executable|library]"
+        return 1
+    fi
+    if [ -d "$name" ]; then
+        caddie cli:red "Error: Directory '$name' already exists"
+        return 1
+    fi
+    local type="executable"
+    if [ "$1" = "--type" ] && [ -n "$2" ]; then
+        type="$2"
+        shift 2 || true
+    fi
+    caddie cli:title "Creating Swift package '$name' (type: $type)..."
+    swift package init --name "$name" --type "$type"
+    cat > "$name/.gitignore" <<'GIT'
+/.build
+/DerivedData
+/.swiftpm
+Package.resolved
+GIT
+    caddie cli:check "Swift package '$name' created"
+    caddie cli:indent "Location: $(pwd)/$name"
+    caddie cli:indent "Build: cd $name && caddie swift:build"
+}
+
+function caddie_swift_build() {
+    caddie_swift_require_package || return 1
+    caddie cli:title "Building Swift package..."
+    swift build "$@"
+    local status=$?
+    if [ $status -eq 0 ]; then
+        caddie cli:check "Swift build completed"
+    else
+        caddie cli:red "Swift build failed ($status)"
+    fi
+    return $status
+}
+
+function caddie_swift_test() {
+    caddie_swift_require_package || return 1
+    caddie cli:title "Running Swift tests..."
+    swift test "$@"
+    local status=$?
+    if [ $status -eq 0 ]; then
+        caddie cli:check "Swift tests completed"
+    else
+        caddie cli:red "Swift tests failed ($status)"
+    fi
+    return $status
+}
+
+function caddie_swift_test_filter() {
+    caddie_swift_require_package || return 1
+    local filter="$1"
+    if [ -z "$filter" ]; then
+        caddie cli:red "Error: Provide an XCTest filter"
+        caddie cli:usage "caddie swift:test:filter <TestCase/testMethod>"
+        return 1
+    fi
+    caddie cli:title "Running tests matching '$filter'..."
+    swift test --filter "$filter"
+}
+
+function caddie_swift_run() {
+    caddie_swift_require_package || return 1
+    caddie cli:title "Running Swift target..."
+    swift run "$@"
+}
+
+function caddie_swift_run_tool() {
+    caddie_swift_require_package || return 1
+    local target="$1"
+    shift || true
+    if [ -z "$target" ]; then
+        caddie cli:red "Error: Provide an executable target"
+        caddie cli:usage "caddie swift:run:tool <target> [-- <args>]"
+        return 1
+    fi
+    caddie cli:title "Running Swift target '$target'..."
+    swift run "$target" "$@"
+}
+
+function caddie_swift_package_resolve() {
+    caddie_swift_require_package || return 1
+    caddie cli:title "Resolving Swift package dependencies..."
+    swift package resolve
+}
+
+function caddie_swift_package_update() {
+    caddie_swift_require_package || return 1
+    caddie cli:title "Updating Swift package dependencies..."
+    swift package update
+}
+
+function caddie_swift_package_clean() {
+    caddie_swift_require_package || return 1
+    caddie cli:title "Cleaning Swift package build artifacts..."
+    swift package clean
+    rm -rf .build
+    caddie cli:check "Clean complete"
+}
+
+function caddie_swift_package_describe() {
+    caddie_swift_require_package || return 1
+    swift package describe
+}
+
+function caddie_swift_format() {
+    caddie_swift_require_package || return 1
+    if ! command -v swift-format >/dev/null 2>&1; then
+        caddie cli:red "swift-format not installed"
+        caddie cli:thought "Install via Homebrew: brew install swift-format"
+        return 1
+    fi
+    local mode="format"
+    if [ "$1" = "--lint" ] || [ "$1" = "--check" ]; then
+        mode="lint"
+    fi
+    if [ "$mode" = "lint" ]; then
+        caddie cli:title "Checking Swift formatting..."
+        swift-format lint --recursive Sources Tests
+    else
+        caddie cli:title "Formatting Swift sources..."
+        swift-format format --in-place --recursive Sources Tests
+    fi
+}
+
+function caddie_swift_lint() {
+    caddie_swift_require_package || return 1
+    if ! command -v swiftlint >/dev/null 2>&1; then
+        caddie cli:red "SwiftLint not installed"
+        caddie cli:thought "Install via Homebrew: brew install swiftlint"
+        return 1
+    fi
+    caddie cli:title "Running SwiftLint..."
+    swiftlint "$@"
+}
+
+function caddie_swift_gitignore() {
+    caddie cli:title "Writing Swift .gitignore..."
+    cat > .gitignore <<'GIT'
+/.build
+/DerivedData
+/.swiftpm
+Package.resolved
+.xcodeproj
+xcuserdata/
+*.xcworkspace
+*.xcodeproj
+*.DS_Store
+GIT
+    caddie cli:check "Swift .gitignore ready"
+}
+
+function caddie_swift_help() {
+    caddie cli:title "Swift Package Manager Commands"
+    caddie cli:usage "caddie swift:<command>"
+    caddie cli:blank
+    caddie cli:title "Project"
+    caddie cli:indent "init <name> [--type ...]   Create new Swift package"
+    caddie cli:indent "build [args]              Run swift build"
+    caddie cli:indent "run [args]                Run default executable"
+    caddie cli:indent "run:tool <target> [--]    Run named executable"
+    caddie cli:indent "test [args]               Run swift test"
+    caddie cli:indent "test:filter <pattern>     swift test --filter"
+    caddie cli:blank
+    caddie cli:title "Package"
+    caddie cli:indent "package:resolve          swift package resolve"
+    caddie cli:indent "package:update           swift package update"
+    caddie cli:indent "package:clean            Remove build artifacts"
+    caddie cli:indent "package:describe         Show dependency graph"
+    caddie cli:blank
+    caddie cli:title "Quality"
+    caddie cli:indent "format [--lint]          Run swift-format"
+    caddie cli:indent "lint [args]              Run SwiftLint"
+    caddie cli:blank
+    caddie cli:title "Git"
+    caddie cli:indent "gitignore                Write Swift .gitignore"
+}
+
+function caddie_swift_description() {
+    echo 'Swift Package Manager helpers'
+}
+
+export -f caddie_swift_require_toolchain
+export -f caddie_swift_require_package
+export -f caddie_swift_init
+export -f caddie_swift_build
+export -f caddie_swift_test
+export -f caddie_swift_test_filter
+export -f caddie_swift_run
+export -f caddie_swift_run_tool
+export -f caddie_swift_package_resolve
+export -f caddie_swift_package_update
+export -f caddie_swift_package_clean
+export -f caddie_swift_package_describe
+export -f caddie_swift_format
+export -f caddie_swift_lint
+export -f caddie_swift_gitignore
+export -f caddie_swift_help
+export -f caddie_swift_description


### PR DESCRIPTION
## Changes\n\n- bug fix on old ch command
- first pass at adding swift to the tooling\n\n## Description\n\nThis PR includes the changes from the current branch.\n\n## Testing\n\n- [ ] Code has been tested\n- [ ] All tests pass\n- [ ] Documentation updated (if needed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a SwiftPM module with build/run/test/format/lint commands, updates install/completion/docs, replaces legacy ch-cli calls, and bumps version to 4.0.0.
> 
> - **New module: `swift`**
>   - Adds `modules/dot_caddie_swift` with SwiftPM helpers: `swift:init`, `swift:build`, `swift:run`, `swift:run:tool`, `swift:test`, `swift:test:filter`, `swift:package:*`, `swift:format`, `swift:lint`, `swift:gitignore`, `swift:help`.
>   - Registers tab completion for all `swift:*` commands in `dot_caddie`.
> - **Installation & integration**
>   - `Makefile`: installs `.caddie_swift` into `~/.caddie_modules`.
>   - `dot_caddie`: autoloads and exposes `swift` commands in completion.
> - **Shell cleanup**
>   - `dot_bashrc`: replace legacy `ch-cli` calls with `caddie cli:*`; keep brew completion hook.
> - **Docs & notes**
>   - `README.md`: add Swift feature.
>   - `docs/modules/README.md` and new `docs/modules/swift.md`: document Swift workflows.
>   - `RELEASE_NOTES.md`: add 4.0.0 entry (Swift module and shell color function update).
> - **Versioning**
>   - `dot_caddie_version`: bump to `4.0.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10659dffd8988f084e46f3ff3107f0c4156b041b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->