### PR TITLE
Release 9.3.7: agent exec, skill module, JS exit codes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,7 @@ echo "$(GREEN)    ✓$(NC) Successfully installed $(DEST_MODULES_DIR)/.caddie_<m
 
 4. **Expose tab completion**: Implement `caddie_<module>_commands()` to print a space-separated list of `<module>:command` entries (or call `caddie_completion_register "<module>" "<module>:command1 …"` inside the module). Caddie will invoke these during module discovery—no manual edits to `_caddie_completion` are required.
 
-5. **Agent skill** (when release-visible behavior changes): Bump `dot_caddie_version` and set `skills/caddie/SKILL.md` frontmatter `caddie-version` to the same value. Users run `make install-dot`, `caddie reload`, and `caddie skill:update`.
+5. **Agent skill** (when release-visible **usage** changes for agents): Bump `dot_caddie_version` and set `skills/caddie/SKILL.md` frontmatter `caddie-version` to the same value. Update `skills/caddie/references/using-caddie.md` when command discovery or module usage guidance changes — keep development rules out of the shipped skill (see `AGENTS.md`). Users run `make install-dot`, `caddie reload`, and `caddie skill:update`.
 
 6. **Test installation**:
 ```sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,9 @@ echo "$(GREEN)    ✓$(NC) Successfully installed $(DEST_MODULES_DIR)/.caddie_<m
 
 4. **Expose tab completion**: Implement `caddie_<module>_commands()` to print a space-separated list of `<module>:command` entries (or call `caddie_completion_register "<module>" "<module>:command1 …"` inside the module). Caddie will invoke these during module discovery—no manual edits to `_caddie_completion` are required.
 
-5. **Test installation**:
+5. **Agent skill** (when release-visible behavior changes): Bump `dot_caddie_version` and set `skills/caddie/SKILL.md` frontmatter `caddie-version` to the same value. Users run `make install-dot`, `caddie reload`, and `caddie skill:update`.
+
+6. **Test installation**:
 ```sh
 make install-dot
 caddie reload

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,11 +123,11 @@ echo "$(GREEN)    ✓$(NC) Successfully installed $(DEST_MODULES_DIR)/.caddie_<m
 
 4. **Expose tab completion**: Implement `caddie_<module>_commands()` to print a space-separated list of `<module>:command` entries (or call `caddie_completion_register "<module>" "<module>:command1 …"` inside the module). Caddie will invoke these during module discovery—no manual edits to `_caddie_completion` are required.
 
-5. **Agent skill** (when release-visible **usage** changes for agents): Bump `dot_caddie_version` and set `skills/caddie/SKILL.md` frontmatter `caddie-version` to the same value. Update `skills/caddie/references/using-caddie.md` when command discovery or module usage guidance changes — keep development rules out of the shipped skill (see `AGENTS.md`). Users run `make install-dot`, `caddie reload`, and `caddie skill:update`.
+5. **Agent skill** (when release-visible **usage** changes for agents): Bump `dot_caddie_version` and set `skills/caddie/SKILL.md` frontmatter `caddie-version` to the same value. Update `skills/caddie/references/using-caddie.md` when command discovery or module usage guidance changes — keep development rules out of the shipped skill (see `AGENTS.md`). Users upgrade with **`make install`**, then `caddie reload` and `caddie skill:update`.
 
-6. **Test installation**:
+6. **Test installation** (caddie developers may use `make install-dot` for speed; **`make install`** for full verification):
 ```sh
-make install-dot
+make install
 caddie reload
 caddie <module>:help
 caddie <module>:command1 test
@@ -243,9 +243,13 @@ The linter is now universal - it can lint any shell script, not just caddie modu
    caddie help
    ```
 
-**For subsequent updates** (when caddie is already installed):
+**For subsequent updates:**
+
+- **Users (recommended):** `make install` then `caddie reload` — refreshes modules, Homebrew, and toolchains.
+- **Caddie development only:** `make install-dot` then `caddie reload` — fast module/dot-file reinstall without full toolchain setup.
+
 ```bash
-make install-dot
+make install
 caddie reload
 ```
 
@@ -366,7 +370,8 @@ function caddie_<module>_<config>_unset() {
 * Always prefer `caddie <module>:<command>` instead of raw language-specific commands
 * Use `caddie reload` after making changes to reload the environment
 * Test with `caddie <module>:help` to verify module integration
-* Use `make install-dot` followed by `caddie reload` to reinstall after changes
+* Use **`make install`** for routine upgrades after pulling caddie.sh
+* Use `make install-dot` followed by `caddie reload` **only when developing caddie modules** in this repository
 
 ### When Adding New Modules
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ WHITE := \033[0;37m
 NC := \033[0m # No Color
 
 # Default target
-.PHONY: all install help
+.PHONY: all install help pull-if-main
 .DEFAULT_GOAL := help
 .SILENT:
 
@@ -32,7 +32,7 @@ help: ## Show this help message
 	echo ""
 	echo "$(YELLOW)Usage:$(NC)"
 	echo "  make install        - Full installation (recommended)"
-	echo "  make install-dot    - Install only dot files (with backup)"
+	echo "  make install-dot    - Dot files/modules only (caddie development)"
 	echo "  make setup-dev      - Setup development environment (Homebrew, Python, Rust, Ruby deps, GitHub CLI)"
 	echo "  make setup-github   - Setup GitHub CLI only"
 	echo "  make backup-existing - Backup existing bash files only"
@@ -51,7 +51,22 @@ help: ## Show this help message
 
 all: install ## Alias for install
 
-install: check-prerequisites install-dot setup-dev ## Complete installation of caddie.sh
+pull-if-main: ## Pull origin/main when the current branch is main
+	echo "$(BLUE)🔄$(NC) Checking for caddie.sh updates..."
+	if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then \
+		echo "$(YELLOW)  →$(NC) Not a git repository; skipping git pull"; \
+	elif [ "$$(git branch --show-current 2>/dev/null)" != "main" ]; then \
+		echo "$(YELLOW)  →$(NC) Not on main (current: $$(git branch --show-current 2>/dev/null || echo unknown)); skipping git pull"; \
+	else \
+		echo "$(YELLOW)  →$(NC) On main; pulling latest from origin..."; \
+		if git pull --ff-only origin main; then \
+			echo "$(GREEN)    ✓$(NC) Repository updated"; \
+		else \
+			echo "$(YELLOW)    →$(NC) git pull skipped (local changes or non-fast-forward); installing from current tree"; \
+		fi; \
+	fi
+
+install: pull-if-main check-prerequisites install-dot setup-dev ## Complete installation of caddie.sh
 	@echo "$(GREEN)✓$(NC) Installation complete! Run 'source ~/.bash_profile' to activate."
 
 check-prerequisites: ## Check system prerequisites

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,13 @@ install-dot: backup-existing ## Install dot files to home directory
 	echo "$(GREEN)    ✓$(NC) Successfully installed $(DEST_MODULES_DIR)/.caddie_debug"
 	cp "$(SRC_MODULES_DIR)/dot_caddie_profile" "$(DEST_MODULES_DIR)/.caddie_profile"
 	echo "$(GREEN)    ✓$(NC) Successfully installed $(DEST_MODULES_DIR)/.caddie_profile"
+	cp "$(SRC_MODULES_DIR)/dot_caddie_skill" "$(DEST_MODULES_DIR)/.caddie_skill"
+	echo "$(GREEN)    ✓$(NC) Successfully installed $(DEST_MODULES_DIR)/.caddie_skill"
+	echo "$(YELLOW)  →$(NC) Installing caddie agent skill (canonical)..."
+	mkdir -p "$(DEST_MODULES_DIR)/skills"
+	rm -rf "$(DEST_MODULES_DIR)/skills/caddie"
+	cp -R skills/caddie "$(DEST_MODULES_DIR)/skills/caddie"
+	echo "$(GREEN)    ✓$(NC) Successfully installed $(DEST_MODULES_DIR)/skills/caddie"
 	echo "$(YELLOW)  →$(NC) Installing caddie binary scripts..."
 	mkdir -p "$(DEST_MODULES_DIR)/bin"
 	if [ -d "$(CADDIE_DIR)/bin" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,14 @@ install-dot: backup-existing ## Install dot files to home directory
 	mkdir -p "$(DEST_MODULES_DIR)/bin"
 	if [ -d "$(CADDIE_DIR)/bin" ]; then \
 		cp "$(CADDIE_DIR)/bin"/* "$(DEST_MODULES_DIR)/bin/" 2>/dev/null || true; \
+		chmod +x "$(DEST_MODULES_DIR)/bin/"* 2>/dev/null || true; \
 		echo "$(GREEN)    ✓$(NC) Successfully installed scripts to $(DEST_MODULES_DIR)/bin"; \
+	fi
+	mkdir -p "$(HOME_DIR)/bin"
+	if [ -f "$(CADDIE_DIR)/bin/caddie" ]; then \
+		cp "$(CADDIE_DIR)/bin/caddie" "$(HOME_DIR)/bin/caddie"; \
+		chmod +x "$(HOME_DIR)/bin/caddie"; \
+		echo "$(GREEN)    ✓$(NC) Successfully installed ~/bin/caddie"; \
 	fi
 	echo "$(YELLOW)  →$(NC) Installing main caddie entry point as ~/.caddie.sh"
 	cp dot_caddie "$(HOME_DIR)/.caddie.sh"

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,8 @@ install-dot: backup-existing ## Install dot files to home directory
 	echo "$(GREEN)    ✓$(NC) Successfully installed $(DEST_MODULES_DIR)/.caddie_cli"
 	cp "$(SRC_MODULES_DIR)/dot_caddie_debug" "$(DEST_MODULES_DIR)/.caddie_debug"
 	echo "$(GREEN)    ✓$(NC) Successfully installed $(DEST_MODULES_DIR)/.caddie_debug"
+	cp "$(SRC_MODULES_DIR)/dot_caddie_profile" "$(DEST_MODULES_DIR)/.caddie_profile"
+	echo "$(GREEN)    ✓$(NC) Successfully installed $(DEST_MODULES_DIR)/.caddie_profile"
 	echo "$(YELLOW)  →$(NC) Installing caddie binary scripts..."
 	mkdir -p "$(DEST_MODULES_DIR)/bin"
 	if [ -d "$(CADDIE_DIR)/bin" ]; then \

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ make your coding experience smooth and efficient.
 - **Cross-Platform**: Multi-language project templates and tools
 - **macOS Utilities**: Screenshot archiving and cleanup helpers
 - **Git Workflow**: Branch management, pull request creation, and GitHub integration
+- **Profile Snippets**: Idempotent PATH and export lines for caddie custom Bash profiles (`caddie path:add`, `caddie profile:add-line`)
 - **IDE Integration**: Cursor IDE integration with AI-powered development
 - **Claude Code Integration**: Onboarding and CLI workflows for Claude Code teams
 - **Git Integration**: Enhanced git workflows with SSH URLs, auto-detection, GitHub integration, and branch management
@@ -70,18 +71,18 @@ caddie reload
 caddie help
 
 # Enter interactive prompt
-caddie  # prompt shows as caddie-9.1.0 (update this for each release)
+caddie  # prompt shows as caddie-9.3.2 (update this for each release)
 
 # Narrow the prompt to a module scope
-caddie-9.3.1 rust  # prompt switches to caddie[rust]-9.3.1
-caddie[rust]-9.3.1 back  # exits scope (also accepts `up` or `..`)
+caddie-9.3.2 rust  # prompt switches to caddie[rust]-9.3.2
+caddie[rust]-9.3.2 back  # exits scope (also accepts `up` or `..`)
 
 # Run shell commands without leaving the REPL
-caddie-9.3.1 `ls -la`
-caddie-9.3.1 shell git status  # one-off shell command
+caddie-9.3.2 `ls -la`
+caddie-9.3.2 shell git status  # one-off shell command
 
 # Cancel a long-running command without leaving the REPL
-caddie-9.3.1 rust build
+caddie-9.3.2 rust build
 # press Ctrl+C → command stops and prompt stays open
 ```
 
@@ -113,6 +114,7 @@ caddie-9.3.1 rust build
 - **[Claude Module](docs/modules/claude.md)** - Claude Code onboarding and CLI helpers
 - **[Debug Module](docs/modules/debug.md)** - Debug control and output helpers
 - **[Git Module](docs/modules/git.md)** - Enhanced git workflows
+- **[Profile Module](docs/modules/profile.md)** - Custom Bash profile snippets (PATH, exports)
 - **[CLI Module](docs/modules/cli.md)** - Color utilities and formatting functions
 - External ecosystem modules—such as [caddie-csv-tools](https://github.com/parnotfar/caddie-csv-tools)—provide additional capabilities when installed separately
 

--- a/README.md
+++ b/README.md
@@ -73,15 +73,15 @@ caddie help
 caddie  # prompt shows as caddie-9.1.0 (update this for each release)
 
 # Narrow the prompt to a module scope
-caddie-9.2.0 rust  # prompt switches to caddie[rust]-9.2.0
-caddie[rust]-9.2.0 back  # exits scope (also accepts `up` or `..`)
+caddie-9.3.0 rust  # prompt switches to caddie[rust]-9.3.0
+caddie[rust]-9.3.0 back  # exits scope (also accepts `up` or `..`)
 
 # Run shell commands without leaving the REPL
-caddie-9.2.0 `ls -la`
-caddie-9.2.0 shell git status  # one-off shell command
+caddie-9.3.0 `ls -la`
+caddie-9.3.0 shell git status  # one-off shell command
 
 # Cancel a long-running command without leaving the REPL
-caddie-9.2.0 rust build
+caddie-9.3.0 rust build
 # press Ctrl+C → command stops and prompt stays open
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ make your coding experience smooth and efficient.
 - **Cross-Platform**: Multi-language project templates and tools
 - **macOS Utilities**: Screenshot archiving and cleanup helpers
 - **Git Workflow**: Branch management, pull request creation, and GitHub integration
-- **Profile Snippets**: Idempotent PATH and export lines for caddie custom Bash profiles (`caddie path:add`, `caddie profile:add-line`)
+- **Profile Snippets**: Source standard or caddie custom Bash profiles (`caddie profile:source`, `caddie profile:custom:source`); idempotent PATH and export lines (`caddie path:add`, `caddie profile:add-line`)
+- **Agent Skill**: Install and update the caddie Cursor/Codex skill (`caddie skill:install:all`, `caddie skill:update`, `caddie skill:audit`)
 - **IDE Integration**: Cursor IDE integration with AI-powered development
 - **Claude Code Integration**: Onboarding and CLI workflows for Claude Code teams
 - **Git Integration**: Enhanced git workflows with SSH URLs, auto-detection, GitHub integration, and branch management
@@ -71,18 +72,18 @@ caddie reload
 caddie help
 
 # Enter interactive prompt
-caddie  # prompt shows as caddie-9.3.2 (update this for each release)
+caddie  # prompt shows as caddie-9.3.4 (update this for each release)
 
 # Narrow the prompt to a module scope
-caddie-9.3.2 rust  # prompt switches to caddie[rust]-9.3.2
-caddie[rust]-9.3.2 back  # exits scope (also accepts `up` or `..`)
+caddie-9.3.4 rust  # prompt switches to caddie[rust]-9.3.4
+caddie[rust]-9.3.4 back  # exits scope (also accepts `up` or `..`)
 
 # Run shell commands without leaving the REPL
-caddie-9.3.2 `ls -la`
-caddie-9.3.2 shell git status  # one-off shell command
+caddie-9.3.4 `ls -la`
+caddie-9.3.4 shell git status  # one-off shell command
 
 # Cancel a long-running command without leaving the REPL
-caddie-9.3.2 rust build
+caddie-9.3.4 rust build
 # press Ctrl+C → command stops and prompt stays open
 ```
 
@@ -115,6 +116,7 @@ caddie-9.3.2 rust build
 - **[Debug Module](docs/modules/debug.md)** - Debug control and output helpers
 - **[Git Module](docs/modules/git.md)** - Enhanced git workflows
 - **[Profile Module](docs/modules/profile.md)** - Custom Bash profile snippets (PATH, exports)
+- **[Skill Module](docs/modules/skill.md)** - Agent skill install, update, and audit
 - **[CLI Module](docs/modules/cli.md)** - Color utilities and formatting functions
 - External ecosystem modules—such as [caddie-csv-tools](https://github.com/parnotfar/caddie-csv-tools)—provide additional capabilities when installed separately
 

--- a/README.md
+++ b/README.md
@@ -73,15 +73,15 @@ caddie help
 caddie  # prompt shows as caddie-9.1.0 (update this for each release)
 
 # Narrow the prompt to a module scope
-caddie-9.3.0 rust  # prompt switches to caddie[rust]-9.3.0
-caddie[rust]-9.3.0 back  # exits scope (also accepts `up` or `..`)
+caddie-9.3.1 rust  # prompt switches to caddie[rust]-9.3.1
+caddie[rust]-9.3.1 back  # exits scope (also accepts `up` or `..`)
 
 # Run shell commands without leaving the REPL
-caddie-9.3.0 `ls -la`
-caddie-9.3.0 shell git status  # one-off shell command
+caddie-9.3.1 `ls -la`
+caddie-9.3.1 shell git status  # one-off shell command
 
 # Cancel a long-running command without leaving the REPL
-caddie-9.3.0 rust build
+caddie-9.3.1 rust build
 # press Ctrl+C → command stops and prompt stays open
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ make your coding experience smooth and efficient.
 - **Git Workflow**: Branch management, pull request creation, and GitHub integration
 - **Profile Snippets**: Source standard or caddie custom Bash profiles (`caddie profile:source`, `caddie profile:custom:source`); idempotent PATH and export lines (`caddie path:add`, `caddie profile:add-line`)
 - **Agent Skill**: Install and update the caddie Cursor/Codex skill (`caddie skill:install:all`, `caddie skill:update`, `caddie skill:audit`)
+- **Agent execution**: Run any module command from Codex/automation shells via `caddie agent:exec` (pairs with `caddie core:module:commands` for discovery)
 - **IDE Integration**: Cursor IDE integration with AI-powered development
 - **Claude Code Integration**: Onboarding and CLI workflows for Claude Code teams
 - **Git Integration**: Enhanced git workflows with SSH URLs, auto-detection, GitHub integration, and branch management
@@ -72,15 +73,15 @@ caddie reload
 caddie help
 
 # Enter interactive prompt
-caddie  # prompt shows as caddie-9.3.4 (update this for each release)
+caddie  # prompt shows as caddie-9.3.5 (update this for each release)
 
 # Narrow the prompt to a module scope
-caddie-9.3.4 rust  # prompt switches to caddie[rust]-9.3.4
-caddie[rust]-9.3.4 back  # exits scope (also accepts `up` or `..`)
+caddie-9.3.5 rust  # prompt switches to caddie[rust]-9.3.5
+caddie[rust]-9.3.5 back  # exits scope (also accepts `up` or `..`)
 
 # Run shell commands without leaving the REPL
-caddie-9.3.4 `ls -la`
-caddie-9.3.4 shell git status  # one-off shell command
+caddie-9.3.5 `ls -la`
+caddie-9.3.5 shell git status  # one-off shell command
 
 # Cancel a long-running command without leaving the REPL
 caddie-9.3.4 rust build

--- a/README.md
+++ b/README.md
@@ -59,9 +59,11 @@ make your coding experience smooth and efficient.
 git clone https://github.com/parnotfar/caddie.sh.git
 cd caddie.sh
 
-# Run the installer
+# Run the full installer (includes Homebrew and toolchain updates)
 make install
 ```
+
+For routine upgrades after `git pull`, run **`make install`** again — on **`main`** it pulls from `origin/main` first (see [Installation Guide](docs/installation.md#updating)).
 
 ### First Use
 
@@ -73,18 +75,18 @@ caddie reload
 caddie help
 
 # Enter interactive prompt
-caddie  # prompt shows as caddie-9.3.5 (update this for each release)
+caddie  # prompt shows as caddie-9.3.7 (update this for each release)
 
 # Narrow the prompt to a module scope
-caddie-9.3.5 rust  # prompt switches to caddie[rust]-9.3.5
-caddie[rust]-9.3.5 back  # exits scope (also accepts `up` or `..`)
+caddie-9.3.7 rust  # prompt switches to caddie[rust]-9.3.6
+caddie[rust]-9.3.6 back  # exits scope (also accepts `up` or `..`)
 
 # Run shell commands without leaving the REPL
-caddie-9.3.5 `ls -la`
-caddie-9.3.5 shell git status  # one-off shell command
+caddie-9.3.7 `ls -la`
+caddie-9.3.7 shell git status  # one-off shell command
 
 # Cancel a long-running command without leaving the REPL
-caddie-9.3.4 rust build
+caddie-9.3.7 rust build
 # press Ctrl+C → command stops and prompt stays open
 ```
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,25 @@
 # Caddie.sh Release Notes
 
+## Version 9.3.0 - Faster Shell Startup
+
+**Release Date:** May 5, 2026
+
+### Shell startup performance
+
+- **Single core load**: `dot_caddie` already sources `.caddie_core` before the module discovery loop. The loader now registers `core` in the module list without sourcing that file again, avoiding duplicate parse and export work.
+- **Idempotent CLI module**: `.caddie_cli` sets `CADDIE_CLI_LOADED` after the first successful load and returns immediately when sourced again. Nested module sources no longer re-run the full CLI parser or repeated `tput` initialization for colors.
+
+### Git module
+
+- **No prompt work at module load**: `dot_caddie_git` no longer sources `~/.caddie_prompt.sh` or calls `set_caddie_prompt` during load (those remain driven once from `dot_caddie` / `PROMPT_COMMAND`). This avoids double-loading the prompt and avoids an extra full prompt rebuild during startup.
+- **`git:custom:source`**: Optional snippets (`~/.bash_profile-caddie-custom`, `~/.bashrc-caddie-custom`) are no longer sourced automatically when the git module loads. Run `caddie git:custom:source` when you want that behavior (for example from `~/.bash_profile` after caddie loads).
+
+### Roadmap (9.4 spike)
+
+- Lazy or staged module loading, static completion manifests, and optional prompt optimizations (for example cheaper behavior outside a git repo) will be explored as follow-up work after measuring real-world gains from 9.3.0.
+
+---
+
 ## Version 9.2.0 - Codex & Claude Code Support
 
 **Release Date:** February 27, 2026

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,44 @@
 # Caddie.sh Release Notes
 
+## Version 9.3.4 - Agent skill install and audit
+
+**Release Date:** May 5, 2026
+
+### New features
+
+- **`skill` module**: Install and audit the caddie agent skill for Cursor and Codex.
+- **Canonical + symlinks**: Skill tree at `~/.caddie_modules/skills/caddie`; installs link there for one-step updates.
+- **Version model**: Skill version matches `CADDIE_SH_VERSION` (update both on every release).
+- **Commands**: `skill:install` (project `.cursor/skills/caddie`), `skill:install:cursor`, `skill:install:codex`, `skill:install:all`, `skill:update`, `skill:audit`, `skill:info`.
+- **Registry**: `~/.caddie_data/skill-installs.registry` tracks install paths for audit.
+- **Shipped package**: Repo `skills/caddie/` installed by `make install-dot`.
+
+### Usage
+
+```bash
+make install-dot
+caddie reload
+caddie skill:install:all
+caddie skill:audit
+```
+
+---
+
+## Version 9.3.3 - Profile source commands
+
+**Release Date:** May 5, 2026
+
+### New features
+
+- **`caddie profile:source`**: Sources `~/.bash_profile` and `~/.bashrc` when present.
+- **`caddie profile:custom:source`**: Sources `~/.bash_profile-caddie-custom` and `~/.bashrc-caddie-custom` when present.
+
+### Breaking changes
+
+- **Removed `caddie git:custom:source`**: Profile loading is no longer under the git module. Use `caddie profile:custom:source` instead.
+
+---
+
 ## Version 9.3.2 - Custom profile PATH helpers
 
 **Release Date:** May 5, 2026
@@ -10,13 +49,13 @@
 - **`caddie path:add <path> [--profile caddie-custom]`**: Writes `export PATH="<path>:$PATH"` to `~/.bash_profile-caddie-custom` by default. Skips duplicates when the path is already present.
 - **`caddie path:add:bashrc` / `caddie path:add:profile`**: Target `~/.bashrc-caddie-custom` or an explicit profile name (`bash-profile` only when requested).
 - **`caddie profile:add-line`**: Lower-level idempotent append for arbitrary export lines.
-- **Next steps**: After adding, caddie prints `caddie git:custom:source` or open a new terminal.
+- **Next steps**: After adding, caddie prints `caddie profile:custom:source` or open a new terminal.
 
 ### Usage example (Postgres)
 
 ```bash
 caddie path:add "$(brew --prefix postgresql@16)/bin" --profile caddie-custom
-caddie git:custom:source
+caddie profile:custom:source
 ```
 
 ---
@@ -43,7 +82,7 @@ caddie git:custom:source
 ### Git module
 
 - **No prompt work at module load**: `dot_caddie_git` no longer sources `~/.caddie_prompt.sh` or calls `set_caddie_prompt` during load (those remain driven once from `dot_caddie` / `PROMPT_COMMAND`). This avoids double-loading the prompt and avoids an extra full prompt rebuild during startup.
-- **`git:custom:source`**: Optional snippets (`~/.bash_profile-caddie-custom`, `~/.bashrc-caddie-custom`) are no longer sourced automatically when the git module loads. Run `caddie git:custom:source` when you want that behavior (for example from `~/.bash_profile` after caddie loads).
+- **Custom profile snippets**: Optional files (`~/.bash_profile-caddie-custom`, `~/.bashrc-caddie-custom`) are no longer sourced automatically at module load. Use `caddie profile:custom:source` (as of 9.3.3; previously `git:custom:source` in 9.3.0–9.3.2).
 
 ### Roadmap (9.4 spike)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,57 @@
 # Caddie.sh Release Notes
 
+## Version 9.3.7 - JS agent execution fixes
+
+**Release Date:** June 2, 2026
+
+### Bug fixes
+
+- **`js:package:run` exit codes**: npm script failures now propagate non-zero exit status (previously always returned 0).
+- **`js:project:*` / `js:framework:*`**: test, build, serve, audit, and related npm invocations now return the underlying command exit code.
+- **`js:package:run` arguments**: Extra args after `--` are forwarded to npm (e.g. `caddie agent:exec js:package:run typecheck -- --incremental false`).
+- **`~/bin/caddie`**: Non-agent commands now exit with the caddie command status.
+- **`caddie()` dispatch**: Module command return codes propagate correctly.
+
+### Agent / JS environment
+
+- **`caddie-agent-exec` / `js` module**: Automatically run `nvm use` when `.nvmrc` is present (each `agent:exec` is a fresh subprocess — `js:use` in a prior invocation does not carry over).
+- **Agent skill**: Documents exit-code checking, `.nvmrc` for Node version, npm arg forwarding, and explicit ban on internal wrapper paths.
+
+### Usage
+
+```bash
+make install
+caddie reload
+caddie skill:update
+```
+
+---
+
+## Version 9.3.6 - Install workflow and documentation
+
+**Release Date:** June 2, 2026
+
+### New features
+
+- **`make install` pulls on `main`**: When run from the caddie.sh repo on branch **`main`**, `make install` runs `git pull --ff-only origin main` before reinstalling dot files, modules, and toolchains. Skipped on other branches, outside a git repo, or when pull cannot fast-forward.
+
+### Documentation
+
+- **`make install` vs `make install-dot`**: User-facing docs now recommend **`make install`** for first install and routine upgrades (includes Homebrew and toolchain updates). **`make install-dot`** is documented as **caddie development only** — fast module/dot reinstall without full toolchain setup.
+- **Agent skill**: Usage-only skill content; upgrade flow documented as `make install`, `caddie reload`, `caddie skill:update`.
+- **`caddie agent:exec`**: Documented as module-agnostic (all installed modules, not JavaScript-only).
+
+### Usage
+
+```bash
+cd caddie.sh   # on main: make install pulls origin/main first
+make install
+caddie reload
+caddie skill:update
+```
+
+---
+
 ## Version 9.3.5 - Agent execution (`caddie agent:exec`)
 
 **Release Date:** June 2, 2026
@@ -8,7 +60,7 @@
 
 - **`caddie agent:exec`**: Public entry point (via `~/bin/caddie`) to run **any** `caddie <module>:<command>` in a clean Bash 4+ subprocess. Module-agnostic — works for `js`, `python`, `rust`, `ruby`, `git`, `github`, `core`, and every other installed module. Intended for Codex, Cursor agents, and CI shells with inherited function noise or incomplete PATH.
 - **`caddie core:module:commands <module>`**: Machine-readable command list (one per line) for agent discovery.
-- **`~/bin/caddie`**: Installed by `make install-dot`; intercepts `agent:exec` before loading caddie in the parent shell.
+- **`~/bin/caddie`**: Installed by **`make install`**; intercepts `agent:exec` before loading caddie in the parent shell.
 - **`caddie_js_commands()`**: Authoritative JS command list; replaces stale hardcoded `js:build` / `js:dev` completion entries.
 - **Agent skill (usage-only)**: Shipped skill teaches `caddie agent:exec` and command discovery; caddie.sh development rules stay in `AGENTS.md` / `docs/caddie-repo-agent-guide.md`.
 
@@ -38,7 +90,7 @@ When the parent shell loads caddie normally, use `caddie <module>:<command>` dir
 ### Usage
 
 ```bash
-make install-dot
+make install
 caddie reload
 caddie skill:update
 caddie agent:exec core:module:commands js
@@ -57,12 +109,12 @@ caddie agent:exec core:module:commands js
 - **Version model**: Skill version matches `CADDIE_SH_VERSION` (update both on every release).
 - **Commands**: `skill:install` (project `.cursor/skills/caddie`), `skill:install:cursor`, `skill:install:codex`, `skill:install:all`, `skill:update`, `skill:audit`, `skill:info`.
 - **Registry**: `~/.caddie_data/skill-installs.registry` tracks install paths for audit.
-- **Shipped package**: Repo `skills/caddie/` installed by `make install-dot`.
+- **Shipped package**: Repo `skills/caddie/` installed by **`make install`**.
 
 ### Usage
 
 ```bash
-make install-dot
+make install
 caddie reload
 caddie skill:install:all
 caddie skill:audit

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,11 @@
 - **Registry**: `~/.caddie_data/skill-installs.registry` tracks install paths for audit.
 - **Shipped package**: Repo `skills/caddie/` installed by `make install-dot`.
 
+### Bug fixes
+
+- **Custom profile persistence**: Installed `~/.bash_profile` and `~/.bashrc` again source `~/.bash_profile-caddie-custom` and `~/.bashrc-caddie-custom` at shell startup (before `~/.caddie.sh`). `path:add` / `profile:add-line` changes apply in new terminals without running `caddie profile:custom:source` each time. Re-run `make install-dot` to refresh an existing `~/.bash_profile`.
+- **`caddie reload` refreshes CLI module**: `caddie reload` (and `caddie profile:source` when it sources `~/.bash_profile`) now unsets `CADDIE_CLI_LOADED` so an updated `~/.caddie_modules/.caddie_cli` is re-sourced in the current shell. Nested module sources during the same init still skip redundant CLI parsing.
+
 ### Usage
 
 ```bash
@@ -82,7 +87,7 @@ caddie profile:custom:source
 ### Git module
 
 - **No prompt work at module load**: `dot_caddie_git` no longer sources `~/.caddie_prompt.sh` or calls `set_caddie_prompt` during load (those remain driven once from `dot_caddie` / `PROMPT_COMMAND`). This avoids double-loading the prompt and avoids an extra full prompt rebuild during startup.
-- **Custom profile snippets**: Optional files (`~/.bash_profile-caddie-custom`, `~/.bashrc-caddie-custom`) are no longer sourced automatically at module load. Use `caddie profile:custom:source` (as of 9.3.3; previously `git:custom:source` in 9.3.0–9.3.2).
+- **Custom profile snippets**: No longer sourced at git module load (startup performance). As of 9.3.4, caddie-installed `~/.bash_profile` / `~/.bashrc` source the custom snippet files at shell startup; use `caddie profile:custom:source` for the current shell only.
 
 ### Roadmap (9.4 spike)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,26 @@
 # Caddie.sh Release Notes
 
+## Version 9.3.2 - Custom profile PATH helpers
+
+**Release Date:** May 5, 2026
+
+### New features
+
+- **`profile` module**: Append idempotent lines to caddie-managed Bash profile snippets without hand-editing shell files.
+- **`caddie path:add <path> [--profile caddie-custom]`**: Writes `export PATH="<path>:$PATH"` to `~/.bash_profile-caddie-custom` by default. Skips duplicates when the path is already present.
+- **`caddie path:add:bashrc` / `caddie path:add:profile`**: Target `~/.bashrc-caddie-custom` or an explicit profile name (`bash-profile` only when requested).
+- **`caddie profile:add-line`**: Lower-level idempotent append for arbitrary export lines.
+- **Next steps**: After adding, caddie prints `caddie git:custom:source` or open a new terminal.
+
+### Usage example (Postgres)
+
+```bash
+caddie path:add "$(brew --prefix postgresql@16)/bin" --profile caddie-custom
+caddie git:custom:source
+```
+
+---
+
 ## Version 9.3.1 - Prompt GitHub account display
 
 **Release Date:** May 5, 2026

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,15 @@
 # Caddie.sh Release Notes
 
+## Version 9.3.1 - Prompt GitHub account display
+
+**Release Date:** May 5, 2026
+
+### Bug fixes
+
+- **PS1 GitHub label**: When `CADDIE_GITHUB_ACCOUNT` is set (`caddie github:account:set`), the prompt `[gh:…]` segment now shows that configured account instead of always mirroring `gh auth status`. This keeps the prompt aligned with Caddie’s clone and repo URL behavior when the stored org or user differs from the GitHub CLI login.
+
+---
+
 ## Version 9.3.0 - Faster Shell Startup
 
 **Release Date:** May 5, 2026

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,51 @@
 # Caddie.sh Release Notes
 
+## Version 9.3.5 - Agent execution (`caddie agent:exec`)
+
+**Release Date:** June 2, 2026
+
+### New features
+
+- **`caddie agent:exec`**: Public entry point (via `~/bin/caddie`) to run **any** `caddie <module>:<command>` in a clean Bash 4+ subprocess. Module-agnostic — works for `js`, `python`, `rust`, `ruby`, `git`, `github`, `core`, and every other installed module. Intended for Codex, Cursor agents, and CI shells with inherited function noise or incomplete PATH.
+- **`caddie core:module:commands <module>`**: Machine-readable command list (one per line) for agent discovery.
+- **`~/bin/caddie`**: Installed by `make install-dot`; intercepts `agent:exec` before loading caddie in the parent shell.
+- **`caddie_js_commands()`**: Authoritative JS command list; replaces stale hardcoded `js:build` / `js:dev` completion entries.
+- **Agent skill (usage-only)**: Shipped skill teaches `caddie agent:exec` and command discovery; caddie.sh development rules stay in `AGENTS.md` / `docs/caddie-repo-agent-guide.md`.
+
+### Agent / automation usage
+
+```bash
+# Discover commands (any module)
+caddie agent:exec core:module:commands js
+caddie agent:exec core:module:commands rust
+caddie agent:exec core:module:commands python
+
+# Run workflows
+caddie agent:exec js:project:test
+caddie agent:exec rust:test:unit
+caddie agent:exec git:status
+caddie agent:exec core:lint modules/dot_caddie_js
+```
+
+When the parent shell loads caddie normally, use `caddie <module>:<command>` directly. `caddie core:agent:exec` is an alias for `caddie agent:exec`.
+
+### Bug fixes
+
+- **Custom profile persistence**: Installed `~/.bash_profile` / `~/.bashrc` source caddie custom snippet files at shell startup.
+- **`caddie reload` refreshes CLI module**: Unsets `CADDIE_CLI_LOADED` before re-sourcing so `.caddie_cli` updates apply in the current shell.
+- **Skill registry**: Per-path project install IDs; `skill:update` syncs install line versions; audit covers Codex/Cursor user paths and directory-copy migration.
+
+### Usage
+
+```bash
+make install-dot
+caddie reload
+caddie skill:update
+caddie agent:exec core:module:commands js
+```
+
+---
+
 ## Version 9.3.4 - Agent skill install and audit
 
 **Release Date:** May 5, 2026
@@ -12,11 +58,6 @@
 - **Commands**: `skill:install` (project `.cursor/skills/caddie`), `skill:install:cursor`, `skill:install:codex`, `skill:install:all`, `skill:update`, `skill:audit`, `skill:info`.
 - **Registry**: `~/.caddie_data/skill-installs.registry` tracks install paths for audit.
 - **Shipped package**: Repo `skills/caddie/` installed by `make install-dot`.
-
-### Bug fixes
-
-- **Custom profile persistence**: Installed `~/.bash_profile` and `~/.bashrc` again source `~/.bash_profile-caddie-custom` and `~/.bashrc-caddie-custom` at shell startup (before `~/.caddie.sh`). `path:add` / `profile:add-line` changes apply in new terminals without running `caddie profile:custom:source` each time. Re-run `make install-dot` to refresh an existing `~/.bash_profile`.
-- **`caddie reload` refreshes CLI module**: `caddie reload` (and `caddie profile:source` when it sources `~/.bash_profile`) now unsets `CADDIE_CLI_LOADED` so an updated `~/.caddie_modules/.caddie_cli` is re-sourced in the current shell. Nested module sources during the same init still skip redundant CLI parsing.
 
 ### Usage
 

--- a/bin/caddie
+++ b/bin/caddie
@@ -7,7 +7,7 @@ _caddie_run_agent_exec() {
     local status=0
 
     if [ ! -x "$agent_exec" ]; then
-        printf '%s\n' "Error: caddie agent bootstrap not found (run make install-dot)" >&2
+        printf '%s\n' "Error: caddie agent bootstrap not found (run make install)" >&2
         return 1
     fi
 
@@ -28,10 +28,11 @@ fi
 
 caddie_main="${HOME}/.caddie.sh"
 if [ ! -f "$caddie_main" ]; then
-    printf '%s\n' "Error: Caddie not found at ${caddie_main} (run make install-dot)" >&2
+    printf '%s\n' "Error: Caddie not found at ${caddie_main} (run make install)" >&2
     exit 1
 fi
 
 # shellcheck disable=SC1090
 source "$caddie_main"
 caddie "$@"
+exit $?

--- a/bin/caddie
+++ b/bin/caddie
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Caddie public entry point — install to ~/bin/caddie
+# Runs agent commands in a clean subprocess without loading caddie in the parent shell.
+
+_caddie_run_agent_exec() {
+    local agent_exec="${HOME}/.caddie_modules/bin/caddie-agent-exec"
+    local status=0
+
+    if [ ! -x "$agent_exec" ]; then
+        printf '%s\n' "Error: caddie agent bootstrap not found (run make install-dot)" >&2
+        return 1
+    fi
+
+    "$agent_exec" "$@"
+    status=$?
+    return "$status"
+}
+
+if [ "$#" -gt 0 ]; then
+    case "$1" in
+        agent:exec|core:agent:exec)
+            shift
+            _caddie_run_agent_exec "$@"
+            exit $?
+            ;;
+    esac
+fi
+
+caddie_main="${HOME}/.caddie.sh"
+if [ ! -f "$caddie_main" ]; then
+    printf '%s\n' "Error: Caddie not found at ${caddie_main} (run make install-dot)" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$caddie_main"
+caddie "$@"

--- a/bin/caddie-agent-exec
+++ b/bin/caddie-agent-exec
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Run caddie in a clean Bash subprocess for agent/automation shells.
+# Usage: caddie-agent-exec js:project:test
+#        caddie-agent-exec core:module:commands js
+
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+    printf '%s\n' "Usage: caddie-agent-exec <module:command> [args...]" >&2
+    printf '%s\n' "Example: caddie-agent-exec js:project:test" >&2
+    exit 1
+fi
+
+bash_bin=""
+for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash 2>/dev/null || true)"; do
+    if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+        bash_bin="$candidate"
+        break
+    fi
+done
+
+if [ -z "$bash_bin" ]; then
+    printf '%s\n' "Error: bash not found" >&2
+    exit 1
+fi
+
+bash_major="$("$bash_bin" -c 'echo "${BASH_VERSINFO[0]}"')"
+if [ "${bash_major:-0}" -lt 4 ]; then
+    printf '%s\n' "Error: caddie requires Bash 4+ (found ${bash_bin})" >&2
+    exit 1
+fi
+
+home_dir="${HOME:-}"
+caddie_entry="${home_dir}/.caddie.sh"
+
+if [ -z "$home_dir" ] || [ ! -f "$caddie_entry" ]; then
+    printf '%s\n' "Error: ${caddie_entry} not found" >&2
+    exit 1
+fi
+
+exec "$bash_bin" --noprofile --norc -c '
+    export HOME="'"$home_dir"'"
+    export TERM="'"${TERM:-dumb}"'"
+    export PATH="'"${PATH:-/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin}"'"
+    export NVM_DIR="'"${NVM_DIR:-$home_dir/.nvm}"'"
+
+    unset CADDIE_CLI_LOADED
+
+    if [ -s "${NVM_DIR}/nvm.sh" ]; then
+        # shellcheck disable=SC1091
+        . "${NVM_DIR}/nvm.sh"
+    fi
+
+    if [ -f "${HOME}/.bash_profile-caddie-custom" ]; then
+        # shellcheck disable=SC1090
+        . "${HOME}/.bash_profile-caddie-custom"
+    fi
+
+    # shellcheck disable=SC1090
+    source "'"$caddie_entry"'"
+    caddie "$@"
+' _ "$@"

--- a/bin/caddie-agent-exec
+++ b/bin/caddie-agent-exec
@@ -51,6 +51,10 @@ exec "$bash_bin" --noprofile --norc -c '
         . "${NVM_DIR}/nvm.sh"
     fi
 
+    if [ -f .nvmrc ] && command -v nvm >/dev/null 2>&1; then
+        nvm use >/dev/null 2>&1 || true
+    fi
+
     if [ -f "${HOME}/.bash_profile-caddie-custom" ]; then
         # shellcheck disable=SC1090
         . "${HOME}/.bash_profile-caddie-custom"

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Welcome to the comprehensive documentation for Caddie.sh, the ultimate developme
 ## Module Reference
 
 - **[Module Documentation](modules/)** - Detailed information for each module
-  - [Core Module](modules/core.md) - Basic functions and debug system
+  - [Core Module](modules/core.md) - Basic functions, debug system, **`caddie agent:exec`**, and **`caddie core:module:commands`**
   - [Python Module](modules/python.md) - Python environment management
   - [Rust Module](modules/rust.md) - Rust development tools
   - [Ruby Module](modules/ruby.md) - Ruby environment management
@@ -34,9 +34,9 @@ Welcome to the comprehensive documentation for Caddie.sh, the ultimate developme
   - [Skill Module](modules/skill.md) - Agent skill install, update, and audit
   - Optional ecosystem modules (e.g. [caddie-csv-tools](https://github.com/parnotfar/caddie-csv-tools)) can be installed separately
 
-### Shared Executables
+### Shared executables
 
-Reusable helper scripts live in the repository `bin/` directory. The installer copies this folder to `~/.caddie_modules/bin`, giving every module a predictable place to locate shared tools. When adding a new cross-cutting utility, drop the executable into `bin/`, ensure it has a shebang plus execute permissions, and invoke it from your module or dotfile.
+The installer copies repository `bin/` to `~/.caddie_modules/bin` and installs **`~/bin/caddie`** as the public CLI entry point. The `caddie agent:exec` subcommand (handled by `~/bin/caddie`) runs any module command in a clean Bash subprocess — useful for Codex and other automation shells. See **[Core Module — Agent and automation](modules/core.md#agent-and-automation)**.
 
 ## Quick Reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Welcome to the comprehensive documentation for Caddie.sh, the ultimate developme
 
 ## Getting Started
 
-- **[Installation Guide](installation.md)** - Complete setup instructions
+- **[Installation Guide](installation.md)** - Complete setup instructions (`make install` for installs and upgrades; `make install-dot` is for caddie development only)
 - **[User Guide](user-guide.md)** - How to use Caddie.sh effectively
 
 ## 🚀 Launch & Community

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,9 @@ Welcome to the comprehensive documentation for Caddie.sh, the ultimate developme
   - [Cross Module](modules/cross.md) - Multi-language templates
   - [Cursor Module](modules/cursor.md) - IDE integration
   - [Git Module](modules/git.md) - Enhanced git workflows
+  - [GitHub Module](modules/github.md) - GitHub account and repository management
+  - [Profile Module](modules/profile.md) - Bash profile sourcing and custom PATH snippets
+  - [Skill Module](modules/skill.md) - Agent skill install, update, and audit
   - Optional ecosystem modules (e.g. [caddie-csv-tools](https://github.com/parnotfar/caddie-csv-tools)) can be installed separately
 
 ### Shared Executables
@@ -54,6 +57,10 @@ caddie core:set:home ~/projects
 
 # Navigate to caddie home
 caddie go:home
+
+# Install agent skill (Cursor / Codex)
+caddie skill:install:all
+caddie skill:audit
 ```
 
 ### Module Help
@@ -62,6 +69,8 @@ caddie go:home
 # Get help for specific module
 caddie python:help
 caddie rust:help
+caddie profile:help
+caddie skill:help
 caddie core:help
 ```
 

--- a/docs/caddie-repo-agent-guide.md
+++ b/docs/caddie-repo-agent-guide.md
@@ -73,7 +73,8 @@ Use the caddie-native flow:
 caddie core:lint
 caddie core:lint modules/dot_caddie_<module>
 caddie core:lint:limit 5 modules/dot_caddie_<module>
-make install-dot
+make install          # users and releases
+make install-dot      # caddie development only (fast module reinstall)
 caddie reload
 caddie <module>:help
 ```
@@ -89,7 +90,7 @@ If the change is release-visible:
 3. Add the matching section in `RELEASE_NOTES.md`.
 4. Ask the user which release type to use if major/minor/bugfix is not clear.
 
-After release, users run `make install-dot`, `caddie reload`, and `caddie skill:update`.
+After release, users run **`make install`**, `caddie reload`, and `caddie skill:update`. Use `make install-dot` only when developing caddie itself.
 
 ## Useful local references
 

--- a/docs/caddie-repo-agent-guide.md
+++ b/docs/caddie-repo-agent-guide.md
@@ -1,6 +1,6 @@
-# Caddie Repo Guide
+# Caddie Repo Guide (contributors only)
 
-Use this reference when working inside the `caddie.sh` repository.
+Use this reference when working **inside the `caddie.sh` repository**. It is **not** shipped with the agent skill install — end-user agents get `skills/caddie/SKILL.md`, which covers **using** caddie, not developing it.
 
 ## Repository map
 
@@ -49,7 +49,7 @@ Avoid:
 4. Add the command functions.
 5. Export public functions.
 6. Update `Makefile` install targets so the module is copied into `~/.caddie_modules`.
-7. Add `skills/caddie/` updates when agent-facing workflow changes (same version as `dot_caddie_version`).
+7. Update `skills/caddie/` when **user-facing command usage** for agents changes (same version as `dot_caddie_version`). Do not put caddie development rules in the shipped skill.
 8. Expose completion with `caddie_<module>_commands()` or `caddie_completion_register`.
 9. Add or update docs in `docs/modules/`.
 10. Validate with lint, install, reload, help, and targeted command checks.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -231,8 +231,9 @@ For project setup and shared exports, prefer caddie's custom profile files inste
 
 ```bash
 # Append PATH idempotently (Postgres example)
-caddie path:add "$(brew --prefix postgresql@16)/bin" --profile caddie-custom
-caddie profile:custom:source
+caddie path:add "$(brew --prefix postgresql@16)/bin"
+# New login shells load ~/.bash_profile-caddie-custom automatically (caddie-installed ~/.bash_profile)
+caddie profile:custom:source   # optional: apply in the current shell now
 
 # Reload standard ~/.bash_profile and ~/.bashrc in the current shell
 caddie profile:source

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -232,7 +232,10 @@ For project setup and shared exports, prefer caddie's custom profile files inste
 ```bash
 # Append PATH idempotently (Postgres example)
 caddie path:add "$(brew --prefix postgresql@16)/bin" --profile caddie-custom
-caddie git:custom:source
+caddie profile:custom:source
+
+# Reload standard ~/.bash_profile and ~/.bashrc in the current shell
+caddie profile:source
 
 # Append any export line
 caddie profile:add-line 'export EDITOR=vim'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -220,6 +220,26 @@ The installer creates a `~/.bash_profile` that sources Caddie.sh. You can custom
 nano ~/.bash_profile
 ```
 
+#### Caddie-managed custom snippets (recommended)
+
+For project setup and shared exports, prefer caddie's custom profile files instead of editing `~/.bash_profile` directly:
+
+| File | Purpose |
+|------|---------|
+| `~/.bash_profile-caddie-custom` | Login-shell additions (default for `path:add`) |
+| `~/.bashrc-caddie-custom` | Interactive bashrc additions |
+
+```bash
+# Append PATH idempotently (Postgres example)
+caddie path:add "$(brew --prefix postgresql@16)/bin" --profile caddie-custom
+caddie git:custom:source
+
+# Append any export line
+caddie profile:add-line 'export EDITOR=vim'
+```
+
+See **[Profile Module](modules/profile.md)** for full command reference.
+
 #### Adding Custom Aliases
 ```bash
 # Add to ~/.bash_profile

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -93,7 +93,7 @@ Release-visible changes should keep the shipped skill in sync with caddie:
 
 1. Bump `dot_caddie_version` and `RELEASE_NOTES.md`.
 2. Set `skills/caddie/SKILL.md` frontmatter `caddie-version` to the same value as `CADDIE_SH_VERSION`.
-3. Update `skills/caddie/references/repo-guide.md` when workflow or layout changes.
+3. Update `skills/caddie/SKILL.md` and `skills/caddie/references/using-caddie.md` when **user-facing command usage** for agents changes (not caddie development rules — see `AGENTS.md` and `docs/caddie-repo-agent-guide.md`).
 4. Run `make install-dot`, `caddie reload`, and `caddie skill:update`.
 
 The canonical install path is `~/.caddie_modules/skills/caddie`. User installs are symlinks via `caddie skill:install:*`. See **[Skill Module](modules/skill.md)** and root **`AGENTS.md`**.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -81,6 +81,23 @@ This structure makes it easy to:
    caddie help
    ```
 
+6. **Install the agent skill** (recommended for AI-assisted work on this repo):
+   ```bash
+   caddie skill:install:all
+   caddie skill:audit
+   ```
+
+## Agent skill package
+
+Release-visible changes should keep the shipped skill in sync with caddie:
+
+1. Bump `dot_caddie_version` and `RELEASE_NOTES.md`.
+2. Set `skills/caddie/SKILL.md` frontmatter `caddie-version` to the same value as `CADDIE_SH_VERSION`.
+3. Update `skills/caddie/references/repo-guide.md` when workflow or layout changes.
+4. Run `make install-dot`, `caddie reload`, and `caddie skill:update`.
+
+The canonical install path is `~/.caddie_modules/skills/caddie`. User installs are symlinks via `caddie skill:install:*`. See **[Skill Module](modules/skill.md)** and root **`AGENTS.md`**.
+
 ## Development Workflow
 
 ### Branch Strategy
@@ -203,7 +220,9 @@ git commit -m "style: format shell scripts with consistent indentation"
 
 ## Adding Tab Completion for New Commands
 
-Caddie.sh uses a flat command structure where all commands (like `help`, `python:lint`, `core:set:home`, `go:home`) are treated as equal options. Tab completion is handled centrally in the `_caddie_completion` function in `dot_caddie`.
+Prefer **`caddie_<module>_commands()`** in your module (or `caddie_completion_register` at module load). Caddie discovers completions during module loading—avoid editing `_caddie_completion` directly when possible.
+
+Caddie.sh uses a flat command structure where all commands (like `help`, `python:lint`, `core:set:home`, `go:home`) are treated as equal options. Tab completion is handled centrally in the `_caddie_completion` function in `dot_caddie` (with per-module fallbacks in the module loader).
 
 ### How Completion Works
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -69,9 +69,9 @@ This structure makes it easy to:
    make setup-dev
    ```
 
-4. **Install Caddie.sh locally**:
+4. **Install Caddie.sh locally** (contributors hacking on caddie may use `make install-dot` for faster iteration; **`make install`** is recommended for first setup):
    ```bash
-   make install-dot
+   make install
    source ~/.bash_profile
    ```
 
@@ -94,7 +94,7 @@ Release-visible changes should keep the shipped skill in sync with caddie:
 1. Bump `dot_caddie_version` and `RELEASE_NOTES.md`.
 2. Set `skills/caddie/SKILL.md` frontmatter `caddie-version` to the same value as `CADDIE_SH_VERSION`.
 3. Update `skills/caddie/SKILL.md` and `skills/caddie/references/using-caddie.md` when **user-facing command usage** for agents changes (not caddie development rules — see `AGENTS.md` and `docs/caddie-repo-agent-guide.md`).
-4. Run `make install-dot`, `caddie reload`, and `caddie skill:update`.
+4. Run **`make install`**, `caddie reload`, and `caddie skill:update` before release. Use `make install-dot` only for quick local module iteration while developing caddie.
 
 The canonical install path is `~/.caddie_modules/skills/caddie`. User installs are symlinks via `caddie skill:install:*`. See **[Skill Module](modules/skill.md)** and root **`AGENTS.md`**.
 
@@ -528,7 +528,7 @@ function caddie_module_command() {
 
 ### Manual Testing
 
-1. **Install your changes**:
+1. **Install your changes** (use `make install-dot` for fast iteration while developing caddie; **`make install`** before release):
    ```bash
    make install-dot
    source ~/.bash_profile

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -35,6 +35,15 @@ This guide covers installation on macOS (primary) and Linux (best effort).
 
 This ensures you're using the latest Bash version with full `mapfile` support, which is required for Caddie.sh's tab completion functionality.
 
+## `make install` vs `make install-dot`
+
+| Target | Use when |
+|--------|----------|
+| **`make install`** | **Default for everyone.** Full install: dot files, caddie modules, Homebrew updates, and development toolchains (Python, Rust, Ruby deps, etc.). Use for first install and routine upgrades. |
+| **`make install-dot`** | **Caddie development only.** Copies dot files and modules without running Homebrew/toolchain setup. Faster iteration when hacking on caddie modules in this repository — not recommended for day-to-day upgrades. |
+
+User-facing docs and upgrade flows should say **`make install`** from the caddie.sh repo on **`main`** (pulls latest automatically), then `caddie reload` (and `caddie skill:update` when the agent skill changed).
+
 ## Installation Methods
 
 ### Method 1: Quick Install (Recommended)
@@ -58,16 +67,17 @@ This will:
 - Install Ruby build dependencies (OpenSSL, readline, libyaml, etc.) for compiling Ruby
 - Enable cross-platform Rust development for iOS, WatchOS, and Android
 
-### Method 2: Minimal Install
+### Method 2: Dot files only (caddie developers)
 
-If you only want the core Caddie.sh functionality without development tools:
+**Not for routine use.** Installs caddie dot files and modules only — skips Homebrew and toolchain setup. Use when developing caddie.sh and you need a fast reinstall loop:
 
 ```bash
-# Clone and install dot files only
-git clone https://github.com/parnotfar/caddie.sh.git
 cd caddie.sh
 make install-dot
+caddie reload
 ```
+
+For normal installs and upgrades, use **`make install`** (Method 1).
 
 ### Method 3: Development Tools Only
 
@@ -129,7 +139,7 @@ caddie python:create test-env
 
 ### Step 5: Install the Agent Skill (Recommended)
 
-Caddie ships an agent skill for Cursor and Codex. After installation (`make install` or `make install-dot`), install user-level symlinks:
+Caddie ships an agent skill for Cursor and Codex. After **`make install`**, install user-level symlinks:
 
 ```bash
 caddie reload
@@ -197,7 +207,7 @@ See **[Skill Module](modules/skill.md)** for details. Skill version matches `cad
 
 7. **Refresh agent skill after caddie upgrades**:
    ```bash
-   make install-dot
+   make install
    caddie reload
    caddie skill:update
    caddie skill:audit
@@ -287,8 +297,8 @@ To remove specific components:
 
 ```bash
 # Remove only Caddie.sh (keep dev tools)
-make install-dot
-# Then manually remove ~/.caddie* files
+make uninstall
+# Or manually remove ~/.caddie* files
 
 # Remove only development tools
 # Manually uninstall Homebrew, Python, Rust
@@ -298,11 +308,16 @@ make install-dot
 
 ### Update Caddie.sh
 
+From your local `caddie.sh` clone on **`main`**, **`make install`** pulls the latest from `origin/main` (fast-forward only), then reinstalls dot files, modules, and toolchains:
+
 ```bash
 cd caddie.sh
-git pull origin main
-make install-dot
+make install
+caddie reload
+caddie skill:update   # when the agent skill package changed
 ```
+
+On a feature branch, `make install` skips `git pull` and installs from your current tree. To update manually on another branch: `git pull`, then `make install`.
 
 ### Update Development Tools
 
@@ -325,12 +340,11 @@ make install
 
 ### Module Selection
 
-To install only specific modules:
+To install only specific modules manually (advanced):
 
 ```bash
-# Install core and Python only
-make install-dot
-# Then manually copy desired module files
+# Prefer make install for a supported path; manual copy is for experimentation only
+# See docs/contributing.md for caddie module development
 ```
 
 ### Network Configuration

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -146,6 +146,8 @@ caddie skill:install
 
 See **[Skill Module](modules/skill.md)** for details. Skill version matches `caddie --version`; run `caddie skill:update` after upgrading caddie.
 
+**Codex / agent shells:** `~/bin/caddie` supports **`caddie agent:exec`** for any module (JavaScript, Rust, Python, git, …) when the parent shell cannot load caddie normally. See **[Core Module — Agent and automation](modules/core.md#agent-and-automation)**.
+
 ## Post-Installation Setup
 
 ### First-Time Configuration

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -31,7 +31,7 @@ This guide covers installation on macOS (primary) and Linux (best effort).
    - Enter: `/opt/homebrew/bin/bash --login`
    - **Do NOT check "Run inside shell"**
 
-![Terminal Profile Configuration](terminal-profile-config.png)
+*(Terminal profile screenshot: configure “Run command” as `/opt/homebrew/bin/bash --login` without “Run inside shell”.)*
 
 This ensures you're using the latest Bash version with full `mapfile` support, which is required for Caddie.sh's tab completion functionality.
 
@@ -129,7 +129,7 @@ caddie python:create test-env
 
 ### Step 5: Install the Agent Skill (Recommended)
 
-Caddie ships an agent skill for Cursor and Codex. Install user-level symlinks after `make install-dot`:
+Caddie ships an agent skill for Cursor and Codex. After installation (`make install` or `make install-dot`), install user-level symlinks:
 
 ```bash
 caddie reload
@@ -189,7 +189,7 @@ See **[Skill Module](modules/skill.md)** for details. Skill version matches `cad
 6. **Custom Bash profile snippets** (Optional):
    ```bash
    # Add PATH for a tool without editing ~/.bash_profile by hand
-   caddie path:add "$(brew --prefix postgresql@16)/bin" --profile caddie-custom
+   caddie path:add "$(brew --prefix postgresql@16)/bin"
    caddie profile:custom:source
    ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -127,6 +127,25 @@ caddie help
 caddie python:create test-env
 ```
 
+### Step 5: Install the Agent Skill (Recommended)
+
+Caddie ships an agent skill for Cursor and Codex. Install user-level symlinks after `make install-dot`:
+
+```bash
+caddie reload
+caddie skill:install:all
+caddie skill:audit
+```
+
+For a single repository (project-local Cursor skill):
+
+```bash
+cd /path/to/your/project
+caddie skill:install
+```
+
+See **[Skill Module](modules/skill.md)** for details. Skill version matches `caddie --version`; run `caddie skill:update` after upgrading caddie.
+
 ## Post-Installation Setup
 
 ### First-Time Configuration
@@ -165,6 +184,21 @@ caddie python:create test-env
    
    # Check for build artifacts in git
    caddie rust:git:status
+   ```
+
+6. **Custom Bash profile snippets** (Optional):
+   ```bash
+   # Add PATH for a tool without editing ~/.bash_profile by hand
+   caddie path:add "$(brew --prefix postgresql@16)/bin" --profile caddie-custom
+   caddie profile:custom:source
+   ```
+
+7. **Refresh agent skill after caddie upgrades**:
+   ```bash
+   make install-dot
+   caddie reload
+   caddie skill:update
+   caddie skill:audit
    ```
 
 ### Environment Variables

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -25,6 +25,7 @@ This directory contains detailed documentation for each Caddie.sh module.
 - **[Debug Module](debug.md)** - Debug control and output helpers
 - **[Git Module](git.md)** - Enhanced git workflows and GitHub integration
 - **[GitHub Module](github.md)** - GitHub account and repository management
+- **[Profile Module](profile.md)** - Custom Bash profile snippets (PATH, exports)
 - **[CLI Module](cli.md)** - Color utilities and formatting functions
 
 ### Optional Ecosystem Modules

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -26,6 +26,7 @@ This directory contains detailed documentation for each Caddie.sh module.
 - **[Git Module](git.md)** - Enhanced git workflows and GitHub integration
 - **[GitHub Module](github.md)** - GitHub account and repository management
 - **[Profile Module](profile.md)** - Custom Bash profile snippets (PATH, exports)
+- **[Skill Module](skill.md)** - Agent skill install, update, and audit
 - **[CLI Module](cli.md)** - Color utilities and formatting functions
 
 ### Optional Ecosystem Modules

--- a/docs/modules/core.md
+++ b/docs/modules/core.md
@@ -264,7 +264,7 @@ caddie agent:exec core:module:commands git
 - Running any module command when `caddie` fails to load in the parent shell
 
 **Requirements:**
-- `make install-dot` (installs `~/bin/caddie`)
+- `make install` (installs `~/bin/caddie` and refreshes modules)
 - Bash 4+ in the subprocess (Homebrew bash on macOS)
 
 ## Linting

--- a/docs/modules/core.md
+++ b/docs/modules/core.md
@@ -221,6 +221,52 @@ caddie reload
 - Must be run from a shell that has caddie loaded
 - Requires `~/.bash_profile` to be properly configured
 
+### Agent and automation
+
+These commands support **all installed modules** (`js`, `python`, `rust`, `ruby`, `git`, `github`, `core`, …). They are not JavaScript-specific.
+
+#### `caddie agent:exec <command> [args...]`
+
+Run any caddie command in a clean Bash 4+ subprocess. Use in agent/Codex/CI shells where the parent environment has inherited function noise, missing PATH, or fails to load caddie.
+
+```bash
+# Discover commands
+caddie agent:exec core:module:commands js
+caddie agent:exec core:module:commands rust
+caddie agent:exec core:module:commands python
+
+# Run workflows
+caddie agent:exec js:project:test
+caddie agent:exec rust:test:unit
+caddie agent:exec python:test
+caddie agent:exec git:gacp "Update docs"
+caddie agent:exec core:lint modules/dot_caddie_core
+```
+
+- **`caddie core:agent:exec`** — equivalent alias when caddie is already loaded in the parent shell.
+- **`~/bin/caddie`** — public entry point; intercepts `agent:exec` before sourcing the full environment in the parent process.
+- Do **not** point agents at internal `~/.caddie_modules/bin/` install paths.
+
+When the parent shell loads caddie normally, use `caddie <module>:<command>` directly without `agent:exec`.
+
+#### `caddie core:module:commands <module>`
+
+Print the authoritative command list for a module, one command per line (machine-readable). In agent shells, run via `caddie agent:exec core:module:commands <module>`.
+
+```bash
+caddie core:module:commands js
+caddie agent:exec core:module:commands git
+```
+
+**Use cases:**
+- Codex, Cursor, or other agents with broken inherited shell state
+- Discovering authoritative commands before running a workflow (`core:module:commands`)
+- Running any module command when `caddie` fails to load in the parent shell
+
+**Requirements:**
+- `make install-dot` (installs `~/bin/caddie`)
+- Bash 4+ in the subprocess (Homebrew bash on macOS)
+
 ## Linting
 
 #### `caddie core:lint [path]`

--- a/docs/modules/core.md
+++ b/docs/modules/core.md
@@ -200,6 +200,7 @@ caddie reload
 
 **What it does:**
 - Sources `~/.bash_profile` to reload all configurations
+- Re-sources `~/.caddie_modules/.caddie_cli` (clears `CADDIE_CLI_LOADED` so CLI helpers and colors refresh in the current shell)
 - Refreshes environment variables and module loading
 - Provides instant recovery from configuration changes
 - Essential for developers making changes to caddie modules

--- a/docs/modules/csv.md
+++ b/docs/modules/csv.md
@@ -942,7 +942,7 @@ caddie csv:query "SELECT * FROM df LIMIT 1"
 
 ```bash
 cd /path/to/caddie.sh
-make install-dot
+make install
 caddie reload
 ```
 

--- a/docs/modules/git.md
+++ b/docs/modules/git.md
@@ -13,7 +13,7 @@ Short git aliases in `dot_bashrc` have been removed; use `caddie git:*` commands
 Git workflow commands do not load custom Bash profile files. For optional snippets in `~/.bash_profile-caddie-custom` or `~/.bashrc-caddie-custom`, use the **[Profile module](profile.md)**:
 
 ```bash
-caddie path:add "$(brew --prefix some-tool)/bin" --profile caddie-custom
+caddie path:add "$(brew --prefix some-tool)/bin"
 caddie profile:custom:source
 ```
 

--- a/docs/modules/git.md
+++ b/docs/modules/git.md
@@ -8,6 +8,17 @@ The Git module (`caddie git:<command>`) offers streamlined git operations with s
 
 Short git aliases in `dot_bashrc` have been removed; use `caddie git:*` commands for the supported workflows.
 
+### Shell profile snippets
+
+Git workflow commands do not load custom Bash profile files. For optional snippets in `~/.bash_profile-caddie-custom` or `~/.bashrc-caddie-custom`, use the **[Profile module](profile.md)**:
+
+```bash
+caddie path:add "$(brew --prefix some-tool)/bin" --profile caddie-custom
+caddie profile:custom:source
+```
+
+To reload standard `~/.bash_profile` and `~/.bashrc` in the current shell, use `caddie profile:source`.
+
 ## Commands
 
 ### Basic Git Operations

--- a/docs/modules/profile.md
+++ b/docs/modules/profile.md
@@ -1,0 +1,111 @@
+# Profile Module
+
+The Profile module appends idempotent lines to caddie-managed Bash profile snippets so project setup docs can configure the shell without telling users to hand-edit `~/.bash_profile`.
+
+## Overview
+
+Caddie loads optional custom snippets via `caddie git:custom:source`:
+
+- `~/.bash_profile-caddie-custom` — default target for login-shell additions
+- `~/.bashrc-caddie-custom` — interactive bashrc additions
+
+The Profile module (`caddie profile:<command>` and `caddie path:<command>`) writes to those files safely. It does **not** modify `~/.zshrc` or `~/.bash_profile` unless you explicitly choose the `bash-profile` target.
+
+## Commands
+
+### PATH management
+
+#### `caddie path:add <path> [--profile caddie-custom]`
+
+Append a PATH export to the chosen profile file. Default profile: `caddie-custom` (`~/.bash_profile-caddie-custom`).
+
+```bash
+caddie path:add "$(brew --prefix postgresql@16)/bin" --profile caddie-custom
+caddie git:custom:source
+```
+
+Writes:
+
+```bash
+export PATH="/opt/homebrew/opt/postgresql@16/bin:$PATH"
+```
+
+If the path string is already present in the target file, caddie skips the duplicate and prints a friendly message.
+
+#### `caddie path:add:bashrc <path>`
+
+Same as `path:add`, but targets `~/.bashrc-caddie-custom`.
+
+```bash
+caddie path:add:bashrc /opt/local/bin
+```
+
+#### `caddie path:add:profile <profile> <path>`
+
+Append a PATH export to a named profile:
+
+| Profile name | File |
+|--------------|------|
+| `caddie-custom` | `~/.bash_profile-caddie-custom` |
+| `bashrc-caddie-custom` | `~/.bashrc-caddie-custom` |
+| `bash-profile` | `~/.bash_profile` (explicit only) |
+
+```bash
+caddie path:add:profile caddie-custom "$(brew --prefix postgresql@16)/bin"
+```
+
+### Generic line append
+
+#### `caddie profile:add-line <line> [--profile caddie-custom]`
+
+Append any shell line idempotently (exact line match). Useful for exports beyond PATH.
+
+```bash
+caddie profile:add-line 'export EDITOR=vim'
+caddie profile:add-line:bashrc 'export EDITOR=vim'
+```
+
+### Information
+
+#### `caddie profile:info`
+
+Show supported profile targets and file paths.
+
+#### `caddie profile:help`
+
+Show command reference and examples.
+
+## After adding lines
+
+Apply changes in the current shell:
+
+```bash
+caddie git:custom:source
+```
+
+Or open a new terminal.
+
+## Project setup documentation pattern
+
+Instead of:
+
+```bash
+echo 'export PATH="/opt/homebrew/opt/postgresql@16/bin:$PATH"' >> ~/.bash_profile
+```
+
+Use:
+
+```bash
+caddie path:add "$(brew --prefix postgresql@16)/bin" --profile caddie-custom
+caddie git:custom:source
+```
+
+## Related commands
+
+- **`caddie git:custom:source`** — Sources `~/.bash_profile-caddie-custom` and `~/.bashrc-caddie-custom` when present.
+
+## Error handling
+
+- Missing path or line → usage message and non-zero exit
+- Unknown profile name → error listing supported profiles
+- Duplicate path or line → yellow notice, no file change

--- a/docs/modules/profile.md
+++ b/docs/modules/profile.md
@@ -9,7 +9,7 @@ The Profile module sources Bash profile files and appends idempotent lines to ca
 | `caddie profile:source` | `~/.bash_profile` and `~/.bashrc` (standard login/interactive files) |
 | `caddie profile:custom:source` | `~/.bash_profile-caddie-custom` and `~/.bashrc-caddie-custom` (caddie-managed snippets) |
 
-Use `path:add` and `profile:add-line` to write to the custom files, then `profile:custom:source` to apply them in the current shell.
+Use `path:add` and `profile:add-line` to write to the custom files. A caddie-installed `~/.bash_profile` sources `~/.bash_profile-caddie-custom` on each new login shell; `~/.bashrc` sources `~/.bashrc-caddie-custom` for non-login shells. Use `profile:custom:source` to apply changes in the **current** shell without reopening the terminal.
 
 ## Commands
 
@@ -39,7 +39,7 @@ Source caddie-managed custom snippets when they exist:
 caddie profile:custom:source
 ```
 
-Use this after `path:add` or `profile:add-line` to pick up new exports without opening a new terminal.
+Use this after `path:add` or `profile:add-line` to pick up new exports in the **current** shell. New terminals load the custom files automatically when `~/.bash_profile` / `~/.bashrc` were installed from caddie (`make install` / `make install-dot`).
 
 ### PATH management
 

--- a/docs/modules/profile.md
+++ b/docs/modules/profile.md
@@ -1,17 +1,45 @@
 # Profile Module
 
-The Profile module appends idempotent lines to caddie-managed Bash profile snippets so project setup docs can configure the shell without telling users to hand-edit `~/.bash_profile`.
+The Profile module sources Bash profile files and appends idempotent lines to caddie-managed snippets so project setup docs can configure the shell without hand-editing `~/.bash_profile`.
 
 ## Overview
 
-Caddie loads optional custom snippets via `caddie git:custom:source`:
+| Command | Loads |
+|---------|--------|
+| `caddie profile:source` | `~/.bash_profile` and `~/.bashrc` (standard login/interactive files) |
+| `caddie profile:custom:source` | `~/.bash_profile-caddie-custom` and `~/.bashrc-caddie-custom` (caddie-managed snippets) |
 
-- `~/.bash_profile-caddie-custom` — default target for login-shell additions
-- `~/.bashrc-caddie-custom` — interactive bashrc additions
-
-The Profile module (`caddie profile:<command>` and `caddie path:<command>`) writes to those files safely. It does **not** modify `~/.zshrc` or `~/.bash_profile` unless you explicitly choose the `bash-profile` target.
+Use `path:add` and `profile:add-line` to write to the custom files, then `profile:custom:source` to apply them in the current shell.
 
 ## Commands
+
+### Load profiles
+
+#### `caddie profile:source`
+
+Source the standard Bash profile files when they exist:
+
+- `~/.bash_profile`
+- `~/.bashrc`
+
+```bash
+caddie profile:source
+```
+
+Missing files are skipped with a warning. If neither file exists, the command fails.
+
+#### `caddie profile:custom:source`
+
+Source caddie-managed custom snippets when they exist:
+
+- `~/.bash_profile-caddie-custom`
+- `~/.bashrc-caddie-custom`
+
+```bash
+caddie profile:custom:source
+```
+
+Use this after `path:add` or `profile:add-line` to pick up new exports without opening a new terminal.
 
 ### PATH management
 
@@ -21,7 +49,7 @@ Append a PATH export to the chosen profile file. Default profile: `caddie-custom
 
 ```bash
 caddie path:add "$(brew --prefix postgresql@16)/bin" --profile caddie-custom
-caddie git:custom:source
+caddie profile:custom:source
 ```
 
 Writes:
@@ -36,34 +64,19 @@ If the path string is already present in the target file, caddie skips the dupli
 
 Same as `path:add`, but targets `~/.bashrc-caddie-custom`.
 
-```bash
-caddie path:add:bashrc /opt/local/bin
-```
-
 #### `caddie path:add:profile <profile> <path>`
 
-Append a PATH export to a named profile:
-
-| Profile name | File |
-|--------------|------|
-| `caddie-custom` | `~/.bash_profile-caddie-custom` |
-| `bashrc-caddie-custom` | `~/.bashrc-caddie-custom` |
-| `bash-profile` | `~/.bash_profile` (explicit only) |
-
-```bash
-caddie path:add:profile caddie-custom "$(brew --prefix postgresql@16)/bin"
-```
+Append a PATH export to a named profile (`caddie-custom`, `bashrc-caddie-custom`, or `bash-profile` for `~/.bash_profile`).
 
 ### Generic line append
 
 #### `caddie profile:add-line <line> [--profile caddie-custom]`
 
-Append any shell line idempotently (exact line match). Useful for exports beyond PATH.
+Append any shell line idempotently (exact line match).
 
-```bash
-caddie profile:add-line 'export EDITOR=vim'
-caddie profile:add-line:bashrc 'export EDITOR=vim'
-```
+#### `caddie profile:add-line:bashrc <line>`
+
+Append to `~/.bashrc-caddie-custom`.
 
 ### Information
 
@@ -75,15 +88,18 @@ Show supported profile targets and file paths.
 
 Show command reference and examples.
 
-## After adding lines
-
-Apply changes in the current shell:
+## Typical workflow
 
 ```bash
-caddie git:custom:source
-```
+# 1. Add PATH for Postgres (writes ~/.bash_profile-caddie-custom)
+caddie path:add "$(brew --prefix postgresql@16)/bin" --profile caddie-custom
 
-Or open a new terminal.
+# 2. Apply custom snippets in this shell
+caddie profile:custom:source
+
+# Or reload standard profiles (includes your main ~/.bash_profile setup)
+caddie profile:source
+```
 
 ## Project setup documentation pattern
 
@@ -97,15 +113,12 @@ Use:
 
 ```bash
 caddie path:add "$(brew --prefix postgresql@16)/bin" --profile caddie-custom
-caddie git:custom:source
+caddie profile:custom:source
 ```
-
-## Related commands
-
-- **`caddie git:custom:source`** — Sources `~/.bash_profile-caddie-custom` and `~/.bashrc-caddie-custom` when present.
 
 ## Error handling
 
 - Missing path or line → usage message and non-zero exit
 - Unknown profile name → error listing supported profiles
 - Duplicate path or line → yellow notice, no file change
+- `profile:source` / `profile:custom:source` with no files found → error

--- a/docs/modules/profile.md
+++ b/docs/modules/profile.md
@@ -39,7 +39,7 @@ Source caddie-managed custom snippets when they exist:
 caddie profile:custom:source
 ```
 
-Use this after `path:add` or `profile:add-line` to pick up new exports in the **current** shell. New terminals load the custom files automatically when `~/.bash_profile` / `~/.bashrc` were installed from caddie (`make install` / `make install-dot`).
+Use this after `path:add` or `profile:add-line` to pick up new exports in the **current** shell. New terminals load the custom files automatically when `~/.bash_profile` / `~/.bashrc` were installed from caddie via **`make install`**.
 
 ### PATH management
 

--- a/docs/modules/skill.md
+++ b/docs/modules/skill.md
@@ -16,6 +16,8 @@ The skill version **matches `CADDIE_SH_VERSION`**. When you release caddie, upda
 | `.cursor/skills/caddie` | Project install in current directory (symlink) |
 | `~/.caddie_data/skill-installs.registry` | Install audit registry |
 
+Each install is one `install|…` line. User installs use fixed ids (`cursor-user`, `codex-user`). Project installs use a per-path id (`cursor-project-<hash>`) so multiple repositories stay registered. `skill:update` refreshes the registry header and rewrites every install line’s `recorded_version` to match caddie.
+
 ## Commands
 
 ### Install
@@ -47,7 +49,7 @@ User-level Cursor + Codex installs.
 
 #### `caddie skill:update`
 
-Copy the packaged skill from `~/.caddie_modules/skills/caddie` (refreshed by `make install-dot`) into the canonical directory and update the registry version.
+Copy the packaged skill from `~/.caddie_modules/skills/caddie` (refreshed by `make install-dot`) into the canonical directory, update the registry header version, and sync `recorded_version` on all registered install lines.
 
 ```bash
 make install-dot
@@ -57,7 +59,9 @@ caddie skill:update
 
 #### `caddie skill:audit`
 
-Verify canonical `SKILL.md` exists, registry version matches caddie, each registered install is a symlink to canonical, and list unregistered symlinks that still point at canonical.
+Verify canonical `SKILL.md` exists, registry version matches caddie, each registered install is a symlink to canonical, check `~/.cursor/skills/caddie` and `~/.codex/skills/caddie` (including directory copies that are not yet symlinked), and list unregistered symlinks that still point at canonical.
+
+If `~/.codex/skills/caddie` (or Cursor’s user path) is a copied directory from an older setup, `caddie skill:install:codex` backs it up and replaces it with a symlink to canonical.
 
 #### `caddie skill:info`
 

--- a/docs/modules/skill.md
+++ b/docs/modules/skill.md
@@ -6,6 +6,29 @@ The Skill module installs and audits the **caddie** agent skill for Cursor and C
 
 The skill version **matches `CADDIE_SH_VERSION`**. When you release caddie, update `dot_caddie_version`, `skills/caddie/SKILL.md` frontmatter (`caddie-version`), and `RELEASE_NOTES.md` together. Users run `make install-dot`, `caddie reload`, and `caddie skill:update`.
 
+## What the skill covers
+
+The shipped skill teaches agents **how to use caddie** — discover modules, run `caddie <module>:<command>`, prefer caddie wrappers for workspace consistency, and fall back to direct tools when needed. It does **not** include caddie.sh development guidelines (those live in repo `AGENTS.md` and `docs/caddie-repo-agent-guide.md` for contributors only).
+
+Agents discover subcommands with `caddie <module>:help` or `caddie agent:exec core:module:commands <module>` (not nested forms like `js:project:help`).
+
+### Using caddie from agents (Cursor / Codex)
+
+The skill teaches agents to run **`caddie agent:exec`** — a **module-agnostic** wrapper that works for any installed module (`js`, `python`, `rust`, `git`, `core`, …):
+
+```bash
+# Discover commands
+caddie agent:exec core:module:commands js
+caddie agent:exec core:module:commands rust
+
+# Run workflows
+caddie agent:exec js:project:test
+caddie agent:exec rust:test:unit
+caddie agent:exec git:status
+```
+
+See **[Core Module — Agent and automation](core.md#agent-and-automation)** for details. The skill does not include caddie.sh development rules.
+
 ## Overview
 
 | Path | Role |
@@ -95,7 +118,7 @@ caddie skill:install
 skills/caddie/
 ├── SKILL.md
 ├── agents/openai.yaml
-└── references/repo-guide.md
+└── references/using-caddie.md
 ```
 
 Do not install into `~/.cursor/skills-cursor/` (reserved for Cursor built-ins).

--- a/docs/modules/skill.md
+++ b/docs/modules/skill.md
@@ -1,0 +1,97 @@
+# Skill Module
+
+The Skill module installs and audits the **caddie** agent skill for Cursor and Codex. One canonical copy lives under `~/.caddie_modules/skills/caddie`; installs are symlinks so `caddie skill:update` refreshes every link at once.
+
+## Version model
+
+The skill version **matches `CADDIE_SH_VERSION`**. When you release caddie, update `dot_caddie_version`, `skills/caddie/SKILL.md` frontmatter (`caddie-version`), and `RELEASE_NOTES.md` together. Users run `make install-dot`, `caddie reload`, and `caddie skill:update`.
+
+## Overview
+
+| Path | Role |
+|------|------|
+| `~/.caddie_modules/skills/caddie/` | Canonical skill tree (from repo `skills/caddie/` on install) |
+| `~/.cursor/skills/caddie` | Typical Cursor user install (symlink) |
+| `~/.codex/skills/caddie` | Typical Codex user install (symlink) |
+| `.cursor/skills/caddie` | Project install in current directory (symlink) |
+| `~/.caddie_data/skill-installs.registry` | Install audit registry |
+
+## Commands
+
+### Install
+
+#### `caddie skill:install` / `caddie skill:install:project`
+
+Refresh canonical, then symlink `.cursor/skills/caddie` in the **current directory** to canonical.
+
+```bash
+cd ~/work/my-project
+caddie skill:install
+```
+
+Consider adding `.cursor/skills/caddie` to `.gitignore` if the link should stay local.
+
+#### `caddie skill:install:cursor`
+
+Symlink `~/.cursor/skills/caddie` → canonical.
+
+#### `caddie skill:install:codex`
+
+Symlink `~/.codex/skills/caddie` → canonical.
+
+#### `caddie skill:install:all`
+
+User-level Cursor + Codex installs.
+
+### Maintenance
+
+#### `caddie skill:update`
+
+Copy the packaged skill from `~/.caddie_modules/skills/caddie` (refreshed by `make install-dot`) into the canonical directory and update the registry version.
+
+```bash
+make install-dot
+caddie reload
+caddie skill:update
+```
+
+#### `caddie skill:audit`
+
+Verify canonical `SKILL.md` exists, registry version matches caddie, each registered install is a symlink to canonical, and list unregistered symlinks that still point at canonical.
+
+#### `caddie skill:info`
+
+Show caddie version, canonical path, registry path, and install count.
+
+## Typical workflow
+
+```bash
+# From caddie.sh repo after clone
+make install-dot
+caddie reload
+
+# User-wide agent skills
+caddie skill:install:all
+caddie skill:audit
+
+# Per-repo (optional)
+cd ~/work/caddie.sh
+caddie skill:install
+```
+
+## Error handling
+
+- **Target path exists but is not a symlink** — install fails; move the directory aside manually, then retry.
+- **Canonical missing** — run `caddie skill:update` or `make install-dot`.
+- **Version mismatch in audit** — run `caddie skill:update` after upgrading caddie.
+
+## Skill package layout
+
+```
+skills/caddie/
+├── SKILL.md
+├── agents/openai.yaml
+└── references/repo-guide.md
+```
+
+Do not install into `~/.cursor/skills-cursor/` (reserved for Cursor built-ins).

--- a/docs/modules/skill.md
+++ b/docs/modules/skill.md
@@ -4,7 +4,7 @@ The Skill module installs and audits the **caddie** agent skill for Cursor and C
 
 ## Version model
 
-The skill version **matches `CADDIE_SH_VERSION`**. When you release caddie, update `dot_caddie_version`, `skills/caddie/SKILL.md` frontmatter (`caddie-version`), and `RELEASE_NOTES.md` together. Users run `make install-dot`, `caddie reload`, and `caddie skill:update`.
+The skill version **matches `CADDIE_SH_VERSION`**. When you release caddie, update `dot_caddie_version`, `skills/caddie/SKILL.md` frontmatter (`caddie-version`), and `RELEASE_NOTES.md` together. Users upgrade with **`make install`**, then `caddie reload` and `caddie skill:update`.
 
 ## What the skill covers
 
@@ -72,10 +72,10 @@ User-level Cursor + Codex installs.
 
 #### `caddie skill:update`
 
-Copy the packaged skill from `~/.caddie_modules/skills/caddie` (refreshed by `make install-dot`) into the canonical directory, update the registry header version, and sync `recorded_version` on all registered install lines.
+Copy the packaged skill from `~/.caddie_modules/skills/caddie` (refreshed by **`make install`**) into the canonical directory, update the registry header version, and sync `recorded_version` on all registered install lines.
 
 ```bash
-make install-dot
+make install
 caddie reload
 caddie skill:update
 ```
@@ -93,8 +93,8 @@ Show caddie version, canonical path, registry path, and install count.
 ## Typical workflow
 
 ```bash
-# From caddie.sh repo after clone
-make install-dot
+# First install or upgrade from caddie.sh repo
+make install
 caddie reload
 
 # User-wide agent skills
@@ -109,7 +109,7 @@ caddie skill:install
 ## Error handling
 
 - **Target path exists but is not a symlink** — install fails; move the directory aside manually, then retry.
-- **Canonical missing** — run `caddie skill:update` or `make install-dot`.
+- **Canonical missing** — run `caddie skill:update` or **`make install`** from the caddie.sh repo.
 - **Version mismatch in audit** — run `caddie skill:update` after upgrading caddie.
 
 ## Skill package layout

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -70,7 +70,7 @@ caddie core:debug status
 3. **Reinstall if missing:**
    ```bash
    cd /path/to/caddie.sh
-   make install-dot
+   make install
    source ~/.bash_profile
    ```
 
@@ -103,7 +103,7 @@ caddie core:debug status
 3. **Reinstall debug system:**
    ```bash
    cd /path/to/caddie.sh
-   make install-dot
+   make install
    source ~/.bash_profile
    ```
 
@@ -138,7 +138,7 @@ caddie core:debug status
    ```bash
    make check-prerequisites
    make backup-existing
-   make install-dot
+   make install
    make setup-dev
    ```
 
@@ -205,7 +205,7 @@ caddie core:debug status
 4. **Reinstall modules:**
    ```bash
    cd /path/to/caddie.sh
-   make install-dot
+   make install
    source ~/.bash_profile
    ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -666,7 +666,7 @@ See **[Profile Module](modules/profile.md)** for all targets and subcommands.
 
 ### Agent Skill (Cursor / Codex)
 
-Install the caddie skill so agents follow repository conventions (`AGENTS.md`, modules, lint, release workflow). Skill version matches `caddie --version`.
+Install the caddie skill so agents use **`caddie <module>:<command>`** consistently across projects. Skill version matches `caddie --version`.
 
 ```bash
 # User-level (Cursor + Codex)
@@ -683,7 +683,16 @@ caddie reload
 caddie skill:update
 ```
 
-See **[Skill Module](modules/skill.md)** for canonical paths and troubleshooting.
+**Agent / Codex shells:** When the parent shell cannot load caddie, use **`caddie agent:exec`** for any module — not JavaScript-only:
+
+```bash
+caddie agent:exec core:module:commands python
+caddie agent:exec rust:test:unit
+caddie agent:exec js:project:build
+caddie agent:exec git:gacp "message"
+```
+
+See **[Skill Module](modules/skill.md)** and **[Core Module — Agent and automation](modules/core.md#agent-and-automation)**.
 
 ### CLI Utilities
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -677,8 +677,8 @@ caddie skill:audit
 cd ~/work/my-project
 caddie skill:install
 
-# After upgrading caddie
-make install-dot
+# After upgrading caddie (from caddie.sh repo)
+make install
 caddie reload
 caddie skill:update
 ```
@@ -847,7 +847,7 @@ Use Caddie.sh in your CI/CD pipelines:
   run: |
     git clone https://github.com/parnotfar/caddie.sh.git
     cd caddie.sh
-    make install-dot
+    make install
     source ~/.bash_profile
     caddie python:create ci-env
     caddie python:activate ci-env

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -49,6 +49,9 @@ Caddie.sh is built around modules, each handling a specific development area:
 - **`mac`**: macOS workflow helpers and utilities
 - **`cursor`**: IDE integration and AI-powered development
 - **`git`**: Enhanced git workflows with SSH URLs, auto-detection, and GitHub integration
+- **`github`**: GitHub account and repository management
+- **`profile`**: Bash profile sourcing and caddie-managed custom snippets (`path:add`, `profile:custom:source`)
+- **`skill`**: Install and audit the caddie agent skill for Cursor and Codex
 - **`cli`**: Color utilities and formatting functions
 
 ### Data Structures
@@ -634,6 +637,54 @@ caddie cursor:ext:update
 caddie cursor:ext:sync
 ```
 
+### Profile and Shell Snippets
+
+Use the profile module to source Bash files and append idempotent lines to caddie-managed custom snippets (without hand-editing `~/.bash_profile` for every project setup doc).
+
+#### Load profiles
+
+```bash
+# Standard login/interactive files
+caddie profile:source
+
+# Caddie custom snippets (~/.bash_profile-caddie-custom, ~/.bashrc-caddie-custom)
+caddie profile:custom:source
+```
+
+#### PATH and exports
+
+```bash
+# Append PATH to ~/.bash_profile-caddie-custom (default)
+caddie path:add "$(brew --prefix postgresql@16)/bin" --profile caddie-custom
+caddie profile:custom:source
+
+# Append any line idempotently
+caddie profile:add-line 'export EDITOR=vim'
+```
+
+See **[Profile Module](modules/profile.md)** for all targets and subcommands.
+
+### Agent Skill (Cursor / Codex)
+
+Install the caddie skill so agents follow repository conventions (`AGENTS.md`, modules, lint, release workflow). Skill version matches `caddie --version`.
+
+```bash
+# User-level (Cursor + Codex)
+caddie skill:install:all
+caddie skill:audit
+
+# Project-local (.cursor/skills/caddie in current directory)
+cd ~/work/my-project
+caddie skill:install
+
+# After upgrading caddie
+make install-dot
+caddie reload
+caddie skill:update
+```
+
+See **[Skill Module](modules/skill.md)** for canonical paths and troubleshooting.
+
 ### CLI Utilities
 
 The CLI module provides sophisticated color output and formatting functions for creating better command-line interfaces:
@@ -734,11 +785,16 @@ source ~/.caddie_prompt.sh
 
 #### Environment Variables
 
-Set custom environment variables:
+Prefer caddie-managed custom profile files for exports and PATH (see [Profile Module](modules/profile.md)):
 
 ```bash
-# Add to your ~/.bash_profile
-export CADDIE_CUSTOM_VAR="value"
+caddie profile:add-line 'export CADDIE_CUSTOM_VAR="value"'
+caddie profile:custom:source
+```
+
+For one-off debugging in the current shell:
+
+```bash
 export CADDIE_DEBUG=1
 ```
 
@@ -938,6 +994,8 @@ caddie help
 
 # Module help
 caddie python:help
+caddie profile:help
+caddie skill:help
 
 # Command help
 caddie core:help
@@ -951,6 +1009,8 @@ Each module exposes an `info` command for quick environment summaries.
 caddie core:info
 caddie python:info
 caddie git:info
+caddie profile:info
+caddie skill:info
 ```
 
 ### External Resources

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -655,7 +655,7 @@ caddie profile:custom:source
 
 ```bash
 # Append PATH to ~/.bash_profile-caddie-custom (default)
-caddie path:add "$(brew --prefix postgresql@16)/bin" --profile caddie-custom
+caddie path:add "$(brew --prefix postgresql@16)/bin"
 caddie profile:custom:source
 
 # Append any line idempotently

--- a/dot_bash_profile
+++ b/dot_bash_profile
@@ -11,4 +11,10 @@ if [ -d "$HOME/.local/bin" ]; then
     export PATH
 fi
 
+# Caddie-managed login snippets (caddie path:add / caddie profile:add-line)
+if [ -f "$HOME/.bash_profile-caddie-custom" ]; then
+    # shellcheck disable=SC1090
+    . "$HOME/.bash_profile-caddie-custom"
+fi
+
 source "$HOME/.caddie.sh"

--- a/dot_bashrc
+++ b/dot_bashrc
@@ -177,3 +177,9 @@ function __brew_completion() {
 }
 
 complete -F __brew_completion brew
+
+# Caddie-managed snippets for non-login shells (caddie path:add:bashrc / profile:add-line:bashrc)
+if [ -f "$HOME/.bashrc-caddie-custom" ]; then
+    # shellcheck disable=SC1090
+    . "$HOME/.bashrc-caddie-custom"
+fi

--- a/dot_caddie
+++ b/dot_caddie
@@ -1269,6 +1269,10 @@ function _caddie_load_modules() {
                       debug)
                         caddie_completion_register "$module_name" "debug:info debug:on debug:off debug:status debug:help"
                         ;;
+                      profile)
+                        caddie_completion_register "$module_name" "profile:add-line profile:add-line:bashrc profile:info profile:help"
+                        caddie_completion_register "path" "path:add path:add:bashrc path:add:profile"
+                        ;;
                       doc)
                         caddie_completion_register "$module_name" "doc:info doc:help doc:setup doc:setup:mdview doc:setup:glow doc:setup:mdcat doc:setup:pandoc doc:install:mdview doc:install:glow doc:install:mdcat doc:install:pandoc doc:preview doc:preview:mdview doc:preview:glow doc:preview:mdcat doc:preview:pdf doc:preview:clean doc:prefer:set doc:prefer:get doc:prefer:unset doc:rendered:dir:set doc:rendered:dir:get doc:rendered:dir:unset"
                         ;;

--- a/dot_caddie
+++ b/dot_caddie
@@ -1199,8 +1199,13 @@ function _caddie_load_modules() {
                 completion_registered=0
                 completion_fn=""
                 completion_output=""
-                source "$file"
-                module_name="$(caddie_extract_module_name "$file")"
+                if [ "$(basename "$file")" = ".caddie_core" ]; then
+                    # Core is already sourced at the top of dot_caddie; register list metadata only.
+                    module_name="core"
+                else
+                    source "$file"
+                    module_name="$(caddie_extract_module_name "$file")"
+                fi
                 caddie_modules_append "$module_name"
                 prompt_fn="caddie_${module_name}_prompt_segment"
                 if declare -F "$prompt_fn" >/dev/null 2>&1; then
@@ -1253,7 +1258,7 @@ function _caddie_load_modules() {
                         caddie_completion_register "$module_name" "cross:info cross:template:create cross:template:list cross:deploy:docker cross:deploy:local cross:deploy:railway"
                         ;;
                       git)
-                        caddie_completion_register "$module_name" "git:status git:info git:branch git:branch:new git:branch:create git:branch:new:feature git:branch:new:bugfix git:branch:new:description git:commit git:gacp git:auth:login git:pr:create git:pr:approve git:push git:push:set:upstream git:pull git:merge:main git:main:merge:branch git:clone git:remote:add git:remote:set-url git:remote:list git:remote:remove git:worktree:list git:worktree:add git:worktree:add:new git:worktree:remove git:worktree:prune git:worktree:lock git:worktree:unlock git:worktree:cd"
+                        caddie_completion_register "$module_name" "git:status git:info git:branch git:branch:new git:branch:create git:branch:new:feature git:branch:new:bugfix git:branch:new:description git:commit git:gacp git:auth:login git:pr:create git:pr:approve git:push git:push:set:upstream git:pull git:merge:main git:main:merge:branch git:clone git:custom:source git:remote:add git:remote:set-url git:remote:list git:remote:remove git:worktree:list git:worktree:add git:worktree:add:new git:worktree:remove git:worktree:prune git:worktree:lock git:worktree:unlock git:worktree:cd"
                         ;;
                       github)
                         caddie_completion_register "$module_name" "github:info github:account:set github:account:get github:account:unset github:auth:check github:repo:create github:repo:url"

--- a/dot_caddie
+++ b/dot_caddie
@@ -957,6 +957,7 @@ function caddie() {
 
     if command -v "$function_name" >/dev/null 2>&1; then
         eval "$function_name \"\$@\""
+        return $?
     else
         caddie cli:red "Error: Unknown command '$command'"
         caddie_help

--- a/dot_caddie
+++ b/dot_caddie
@@ -934,6 +934,8 @@ function caddie() {
             return 0
             ;;
         reload|--reload|-r)
+            # Allow .caddie_cli to re-parse on this reload (nested module sources still skip)
+            unset CADDIE_CLI_LOADED
             source "$HOME/.bash_profile"
             return 0
             ;;

--- a/dot_caddie
+++ b/dot_caddie
@@ -1258,7 +1258,7 @@ function _caddie_load_modules() {
                         caddie_completion_register "$module_name" "cross:info cross:template:create cross:template:list cross:deploy:docker cross:deploy:local cross:deploy:railway"
                         ;;
                       git)
-                        caddie_completion_register "$module_name" "git:status git:info git:branch git:branch:new git:branch:create git:branch:new:feature git:branch:new:bugfix git:branch:new:description git:commit git:gacp git:auth:login git:pr:create git:pr:approve git:push git:push:set:upstream git:pull git:merge:main git:main:merge:branch git:clone git:custom:source git:remote:add git:remote:set-url git:remote:list git:remote:remove git:worktree:list git:worktree:add git:worktree:add:new git:worktree:remove git:worktree:prune git:worktree:lock git:worktree:unlock git:worktree:cd"
+                        caddie_completion_register "$module_name" "git:status git:info git:branch git:branch:new git:branch:create git:branch:new:feature git:branch:new:bugfix git:branch:new:description git:commit git:gacp git:auth:login git:pr:create git:pr:approve git:push git:push:set:upstream git:pull git:merge:main git:main:merge:branch git:clone git:remote:add git:remote:set-url git:remote:list git:remote:remove git:worktree:list git:worktree:add git:worktree:add:new git:worktree:remove git:worktree:prune git:worktree:lock git:worktree:unlock git:worktree:cd"
                         ;;
                       github)
                         caddie_completion_register "$module_name" "github:info github:account:set github:account:get github:account:unset github:auth:check github:repo:create github:repo:url"
@@ -1270,8 +1270,11 @@ function _caddie_load_modules() {
                         caddie_completion_register "$module_name" "debug:info debug:on debug:off debug:status debug:help"
                         ;;
                       profile)
-                        caddie_completion_register "$module_name" "profile:add-line profile:add-line:bashrc profile:info profile:help"
+                        caddie_completion_register "$module_name" "profile:source profile:custom:source profile:add-line profile:add-line:bashrc profile:info profile:help"
                         caddie_completion_register "path" "path:add path:add:bashrc path:add:profile"
+                        ;;
+                      skill)
+                        caddie_completion_register "$module_name" "skill:install skill:install:project skill:install:cursor skill:install:codex skill:install:all skill:update skill:audit skill:info skill:help"
                         ;;
                       doc)
                         caddie_completion_register "$module_name" "doc:info doc:help doc:setup doc:setup:mdview doc:setup:glow doc:setup:mdcat doc:setup:pandoc doc:install:mdview doc:install:glow doc:install:mdcat doc:install:pandoc doc:preview doc:preview:mdview doc:preview:glow doc:preview:mdcat doc:preview:pdf doc:preview:clean doc:prefer:set doc:prefer:get doc:prefer:unset doc:rendered:dir:set doc:rendered:dir:get doc:rendered:dir:unset"

--- a/dot_caddie
+++ b/dot_caddie
@@ -64,6 +64,7 @@ function caddie_help() {
     caddie cli:indent "help                     Show this overview"
     caddie cli:indent "version                  Show caddie version"
     caddie cli:indent "reload                   Reload caddie"
+    caddie cli:indent "agent:exec <cmd>         Run a command in a clean Bash subprocess (agent/Codex shells)"
     caddie cli:indent "(no args)                Launch interactive caddie prompt"
     caddie cli:blank
     caddie cli:title "Productivity:"
@@ -1233,7 +1234,7 @@ function _caddie_load_modules() {
                         caddie_completion_register "$module_name" "ruby:info ruby:setup ruby:install ruby:use ruby:list ruby:current ruby:version ruby:pin:set ruby:pin:get ruby:pin:unset ruby:gemset:create ruby:gemset:use ruby:gemset:list ruby:gemset:delete ruby:gem:install ruby:gem:uninstall ruby:gem:list ruby:gem:update ruby:gem:outdated ruby:project:init ruby:project:test ruby:project:build ruby:project:serve ruby:bundler:install ruby:bundler:update ruby:bundler:exec ruby:rails:new ruby:rails:server ruby:rails:console ruby:rails:generate ruby:rails:migrate ruby:rails:routes"
                         ;;
                       js)
-                        caddie_completion_register "$module_name" "js:info js:init js:install js:add js:update js:build js:dev js:start js:test js:lint js:format js:audit"
+                        caddie_completion_register "$module_name" "js:info js:setup js:install js:use js:list js:version js:help js:project:init js:project:install js:project:update js:project:test js:project:build js:project:serve js:package:install js:package:uninstall js:package:list js:package:update js:package:outdated js:package:audit js:package:run js:package:publish js:framework:create js:framework:serve js:framework:build"
                         ;;
                       rust)
                         caddie_completion_register "$module_name" "rust:info rust:init rust:new rust:build rust:run rust:run:example rust:example:run rust:test rust:test:unit rust:test:integration rust:test:all rust:test:property rust:test:bench rust:test:watch rust:test:coverage rust:add rust:remove rust:fmt rust:fmt:check rust:format rust:format:check rust:clippy rust:check rust:fix rust:fix:all rust:clean rust:update rust:search rust:outdated rust:audit rust:toolchain rust:target rust:component rust:git:status rust:gitignore rust:git:clean"
@@ -1251,7 +1252,7 @@ function _caddie_load_modules() {
                         caddie_completion_register "$module_name" "claude:info claude:init claude:run claude:print claude:continue claude:resume claude:auth:login claude:auth:logout claude:doctor claude:update claude:mcp claude:agents claude:model:set claude:model:get claude:model:unset claude:permission:mode:set claude:permission:mode:get claude:permission:mode:unset"
                         ;;
                       core)
-                        caddie_completion_register "$module_name" "core:info core:status core:set:home core:set:app core:get:app core:help core:aliases core:alias:grep core:alias:git core:alias:docker core:alias:npm core:alias:nav core:lint core:lint:limit"
+                        caddie_completion_register "$module_name" "core:info core:status core:set:home core:set:app core:get:app core:help core:aliases core:alias:grep core:alias:git core:alias:docker core:alias:npm core:alias:nav core:lint core:lint:limit core:module:commands core:agent:exec"
                         ;;
                       cursor)
                         caddie_completion_register "$module_name" "cursor:info cursor:open cursor:new cursor:switch cursor:ai:explain cursor:ai:refactor cursor:ai:test cursor:ai:docs cursor:ai:review cursor:ext:install cursor:ext:recommend cursor:config:restore"

--- a/dot_caddie_prompt
+++ b/dot_caddie_prompt
@@ -71,7 +71,11 @@ function set_caddie_prompt_ps1() {
   local version branch git_info github_info changes github_status="" module_line=""
   version="$(__caddie_version)"
 
-  if command -v gh >/dev/null 2>&1; then
+  # Prefer Caddie's configured default (caddie github:account:set) over the GitHub
+  # CLI login identity, so the prompt matches clone/repo URLs after switching accounts.
+  if [ -n "${CADDIE_GITHUB_ACCOUNT:-}" ]; then
+    github_info="[${PS_GREEN}gh:${CADDIE_GITHUB_ACCOUNT}${PS_RESET}]"
+  elif command -v gh >/dev/null 2>&1; then
     if github_status="$(gh auth status 2>/dev/null)"; then
       if printf '%s' "$github_status" | grep -q "Logged in to github.com account"; then
         local account

--- a/dot_caddie_version
+++ b/dot_caddie_version
@@ -4,7 +4,7 @@
 source "$HOME/.caddie_modules/.caddie_cli"
 
 # Private version variable
-CADDIE_SH_VERSION="9.3.0"
+CADDIE_SH_VERSION="9.3.1"
 
 # Function to get the current version
 function caddie_version_get() {

--- a/dot_caddie_version
+++ b/dot_caddie_version
@@ -4,7 +4,7 @@
 source "$HOME/.caddie_modules/.caddie_cli"
 
 # Private version variable
-CADDIE_SH_VERSION="9.3.2"
+CADDIE_SH_VERSION="9.3.4"
 
 # Function to get the current version
 function caddie_version_get() {

--- a/dot_caddie_version
+++ b/dot_caddie_version
@@ -4,7 +4,7 @@
 source "$HOME/.caddie_modules/.caddie_cli"
 
 # Private version variable
-CADDIE_SH_VERSION="9.2.0"
+CADDIE_SH_VERSION="9.3.0"
 
 # Function to get the current version
 function caddie_version_get() {

--- a/dot_caddie_version
+++ b/dot_caddie_version
@@ -4,7 +4,7 @@
 source "$HOME/.caddie_modules/.caddie_cli"
 
 # Private version variable
-CADDIE_SH_VERSION="9.3.4"
+CADDIE_SH_VERSION="9.3.5"
 
 # Function to get the current version
 function caddie_version_get() {

--- a/dot_caddie_version
+++ b/dot_caddie_version
@@ -4,7 +4,7 @@
 source "$HOME/.caddie_modules/.caddie_cli"
 
 # Private version variable
-CADDIE_SH_VERSION="9.3.1"
+CADDIE_SH_VERSION="9.3.2"
 
 # Function to get the current version
 function caddie_version_get() {

--- a/dot_caddie_version
+++ b/dot_caddie_version
@@ -4,7 +4,7 @@
 source "$HOME/.caddie_modules/.caddie_cli"
 
 # Private version variable
-CADDIE_SH_VERSION="9.3.5"
+CADDIE_SH_VERSION="9.3.7"
 
 # Function to get the current version
 function caddie_version_get() {

--- a/modules/dot_caddie_cli
+++ b/modules/dot_caddie_cli
@@ -1,8 +1,8 @@
 # Caddie.sh CLI Color Module
 # This provides reliable color definitions and CLI utilities for the prompt system
 
-# Idempotent load: every module sources this file; re-sourcing re-parses the file
-# and re-runs many tput calls. Skip after the first successful load.
+# Idempotent load: every module sources this file during one shell init; skip
+# re-parse and repeated tput calls. caddie reload unsets CADDIE_CLI_LOADED first.
 if [[ -n "${CADDIE_CLI_LOADED:-}" ]]; then
   return 0
 fi

--- a/modules/dot_caddie_cli
+++ b/modules/dot_caddie_cli
@@ -1,6 +1,12 @@
 # Caddie.sh CLI Color Module
 # This provides reliable color definitions and CLI utilities for the prompt system
 
+# Idempotent load: every module sources this file; re-sourcing re-parses the file
+# and re-runs many tput calls. Skip after the first successful load.
+if [[ -n "${CADDIE_CLI_LOADED:-}" ]]; then
+  return 0
+fi
+
 # Common colors for reference
 # Note: These use plain ANSI codes (no \[ \]) for regular output, not PS1 prompts
 export BOLD="$(tput bold)"
@@ -398,3 +404,6 @@ export -f caddie_cli_red_bold caddie_cli_green_bold caddie_cli_yellow_bold caddi
 export -f caddie_cli_usage caddie_cli_installed caddie_cli_complete caddie_cli_title caddie_cli_colorlist caddie_cli_help caddie_cli_info
 export -f caddie_cli_check caddie_cli_x caddie_cli_arrow caddie_cli_folder caddie_cli_beer caddie_cli_snake caddie_cli_crab caddie_cli_trash caddie_cli_rotate caddie_cli_chart caddie_cli_magnify caddie_cli_save caddie_cli_warning caddie_cli_debug
 export -f caddie_cli_wrench caddie_cli_whale caddie_cli_package caddie_cli_git caddie_cli_rocket caddie_cli_thought caddie_cli_lightbulb caddie_cli_magnifying_glass caddie_cli_blank caddie_cli_indent
+
+CADDIE_CLI_LOADED=1
+export CADDIE_CLI_LOADED

--- a/modules/dot_caddie_core
+++ b/modules/dot_caddie_core
@@ -866,6 +866,75 @@ function caddie_core_lint_limit() {
     fi
     
     caddie_core_lint "$target" "$limit"
+    return $?
+}
+
+function caddie_core_module_commands() {
+    local module="$1"
+    local commands_fn=""
+    local output=""
+    local cmd=""
+
+    if [ -z "$module" ]; then
+        caddie cli:red "Error: module name required"
+        caddie cli:usage "caddie core:module:commands <module>"
+        caddie cli:thought "Example: caddie core:module:commands js"
+        return 1
+    fi
+
+    commands_fn="caddie_${module}_commands"
+    if declare -F "$commands_fn" >/dev/null 2>&1; then
+        output="$($commands_fn)"
+    else
+        caddie cli:red "Error: No command list for module '${module}'"
+        caddie cli:thought "Try: caddie ${module}:help"
+        return 1
+    fi
+
+    if [ -z "$output" ]; then
+        caddie cli:yellow "No commands registered for module '${module}'"
+        return 1
+    fi
+
+    for cmd in $output; do
+        printf '%s\n' "$cmd"
+    done
+    return 0
+}
+
+function caddie_core_agent_exec() {
+    local agent_exec=""
+    local status=0
+
+    if [ "$#" -eq 0 ]; then
+        caddie cli:red "Error: provide a caddie command"
+        caddie cli:usage "caddie agent:exec <module:command> [args...]"
+        caddie cli:usage "caddie core:agent:exec <module:command> [args...]"
+        caddie cli:thought "Example: caddie agent:exec js:project:test"
+        return 1
+    fi
+
+    agent_exec="${HOME}/.caddie_modules/bin/caddie-agent-exec"
+    if [ ! -x "$agent_exec" ]; then
+        caddie cli:red "Error: caddie agent bootstrap not found (run make install-dot)"
+        return 1
+    fi
+
+    "$agent_exec" "$@"
+    status=$?
+    return "$status"
+}
+
+function caddie_agent_exec() {
+    caddie_core_agent_exec "$@"
+    return $?
+}
+
+function caddie_core_commands() {
+    # caddie:lint:disable
+    printf '%s\n' 'core:info core:status core:set:home core:set:app core:get:app core:help core:aliases core:alias:grep core:alias:git core:alias:docker core:alias:npm core:alias:nav core:lint core:lint:limit core:module:commands core:agent:exec'
+    # caddie:lint:enable
+    return 0
 }
 
 # Function to show core caddie help
@@ -898,6 +967,10 @@ function caddie_core_help() {
     caddie cli:indent "alias:npm            Show npm-related aliases"
     caddie cli:indent "alias:nav            Show navigation aliases"
     caddie cli:blank
+    caddie cli:title "Agent / automation:"
+    caddie cli:indent "module:commands <mod> Machine-readable command list (one per line)"
+    caddie cli:indent "agent:exec <cmd>    Run caddie in a clean Bash subprocess (alias: caddie agent:exec)"
+    caddie cli:blank
     caddie cli:thought "Examples:"
     caddie cli:indent "caddie core:set:home ~/projects/myproject"
     caddie cli:indent "caddie core:get:home"
@@ -910,6 +983,9 @@ function caddie_core_help() {
     caddie cli:indent "caddie core:lint"
     caddie cli:indent "caddie core:lint modules/"
     caddie cli:indent "caddie core:lint:limit 5 modules/dot_caddie_ruby"
+    caddie cli:indent "caddie core:module:commands js"
+    caddie cli:indent "caddie agent:exec js:project:test"
+    return 0
 }
 
 function caddie_core_description() {
@@ -942,3 +1018,7 @@ export -f caddie_core_alias_npm
 export -f caddie_core_alias_nav
 export -f caddie_core_lint
 export -f caddie_core_lint_limit
+export -f caddie_core_module_commands
+export -f caddie_core_agent_exec
+export -f caddie_agent_exec
+export -f caddie_core_commands

--- a/modules/dot_caddie_core
+++ b/modules/dot_caddie_core
@@ -916,7 +916,7 @@ function caddie_core_agent_exec() {
 
     agent_exec="${HOME}/.caddie_modules/bin/caddie-agent-exec"
     if [ ! -x "$agent_exec" ]; then
-        caddie cli:red "Error: caddie agent bootstrap not found (run make install-dot)"
+        caddie cli:red "Error: caddie agent bootstrap not found (run make install)"
         return 1
     fi
 

--- a/modules/dot_caddie_git
+++ b/modules/dot_caddie_git
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# Caddie.sh - Git Prompt and Custom File Management
-# This file handles git prompt setup and custom file sourcing
+# Caddie.sh - Git workflows and optional custom profile snippets
+# Prompt setup lives in ~/.caddie_prompt.sh (sourced from dot_caddie once).
 
 source "$HOME/.caddie_modules/.caddie_cli"
 
@@ -20,15 +20,14 @@ function caddie_source_custom_files() {
     return 0
 }
 
+# Explicit entry point (previously auto-run at module load — see 9.3.0 release notes)
+function caddie_git_custom_source() {
+    caddie_source_custom_files
+    return 0
+}
+
 # Set product name
 export PRODUCT_NAME="Caddie"
-
-# Source and set up our prompt
-source ~/.caddie_prompt.sh
-set_caddie_prompt
-
-# Auto-setup when sourced
-caddie_source_custom_files
 
 # Git workflow functions
 function caddie_git_status() {
@@ -1643,7 +1642,7 @@ function caddie_git_auth_login() {
 }
 
 function caddie_git_commands() {
-    printf '%s\n' "git:status git:info git:branch git:branch:new git:branch:create git:branch:new:feature git:branch:new:bugfix git:branch:new:description git:branch:describe git:branch:delete git:branch:clean:merged git:add git:add:all git:diff git:diff:vim git:log:oneline git:log:graph git:fetch git:fetch:prune git:stash:pop git:stash:clear git:stash:drop git:checkout git:switch git:switch:pull git:commit git:commit:staged git:commit:all git:commit:amend git:commit:amend:all git:commit:push git:gacp git:push git:push:force git:push:set:upstream git:pull git:rebase git:rebase:abort git:rebase:continue git:rebase:skip git:rebase:interactive git:merge:main git:main:merge:branch git:clone git:auth:login git:pr:create git:pr:approve git:remote:add git:remote:set-url git:remote:list git:remote:remove git:worktree:list git:worktree:add git:worktree:add:new git:worktree:remove git:worktree:prune git:worktree:lock git:worktree:unlock git:worktree:cd"
+    printf '%s\n' "git:status git:info git:branch git:branch:new git:branch:create git:branch:new:feature git:branch:new:bugfix git:branch:new:description git:branch:describe git:branch:delete git:branch:clean:merged git:add git:add:all git:diff git:diff:vim git:log:oneline git:log:graph git:fetch git:fetch:prune git:stash:pop git:stash:clear git:stash:drop git:checkout git:switch git:switch:pull git:commit git:commit:staged git:commit:all git:commit:amend git:commit:amend:all git:commit:push git:gacp git:push git:push:force git:push:set:upstream git:pull git:rebase git:rebase:abort git:rebase:continue git:rebase:skip git:rebase:interactive git:merge:main git:main:merge:branch git:clone git:custom:source git:auth:login git:pr:create git:pr:approve git:remote:add git:remote:set-url git:remote:list git:remote:remove git:worktree:list git:worktree:add git:worktree:add:new git:worktree:remove git:worktree:prune git:worktree:lock git:worktree:unlock git:worktree:cd"
     return 0
 }
 
@@ -1652,6 +1651,10 @@ function caddie_git_help() {
     caddie cli:blank
     
     caddie cli:usage "caddie git:<command>"
+    caddie cli:blank
+
+    caddie cli:title "Profile integration:"
+    caddie cli:indent "custom:source         Load ~/.bash_profile-caddie-custom and ~/.bashrc-caddie-custom (if present)"
     caddie cli:blank
     
     caddie cli:title "Basics:"
@@ -1757,6 +1760,7 @@ function caddie_git_help() {
     caddie cli:indent "caddie git:worktree:add ../repo-worktree feature/analytics"
     caddie cli:indent "caddie git:worktree:add:new ../repo-worktree feature/analytics"
     caddie cli:indent "caddie git:worktree:list"
+    caddie cli:indent "caddie git:custom:source"
     caddie cli:blank
     caddie cli:title "Setup GitHub Integration:"
     caddie cli:indent "caddie github:account:set <account>  Set GitHub account"
@@ -1774,6 +1778,7 @@ function caddie_git_description() {
 
 # Export functions for external use
 export -f caddie_source_custom_files
+export -f caddie_git_custom_source
 export -f caddie_git_status
 export -f caddie_git_branch
 export -f caddie_git_branch_candidates

--- a/modules/dot_caddie_git
+++ b/modules/dot_caddie_git
@@ -1,30 +1,9 @@
 #!/usr/bin/env bash
 
-# Caddie.sh - Git workflows and optional custom profile snippets
+# Caddie.sh - Git workflows
 # Prompt setup lives in ~/.caddie_prompt.sh (sourced from dot_caddie once).
 
 source "$HOME/.caddie_modules/.caddie_cli"
-
-# Function to source custom files
-function caddie_source_custom_files() {
-    # Source custom bash profile additions
-    if [ -f "$HOME/.bash_profile-caddie-custom" ]; then
-        source "$HOME/.bash_profile-caddie-custom"
-    fi
-    
-    # Source custom bashrc additions
-    if [ -f "$HOME/.bashrc-caddie-custom" ]; then
-        source "$HOME/.bashrc-caddie-custom"
-    fi
-
-    return 0
-}
-
-# Explicit entry point (previously auto-run at module load — see 9.3.0 release notes)
-function caddie_git_custom_source() {
-    caddie_source_custom_files
-    return 0
-}
 
 # Set product name
 export PRODUCT_NAME="Caddie"
@@ -1642,7 +1621,7 @@ function caddie_git_auth_login() {
 }
 
 function caddie_git_commands() {
-    printf '%s\n' "git:status git:info git:branch git:branch:new git:branch:create git:branch:new:feature git:branch:new:bugfix git:branch:new:description git:branch:describe git:branch:delete git:branch:clean:merged git:add git:add:all git:diff git:diff:vim git:log:oneline git:log:graph git:fetch git:fetch:prune git:stash:pop git:stash:clear git:stash:drop git:checkout git:switch git:switch:pull git:commit git:commit:staged git:commit:all git:commit:amend git:commit:amend:all git:commit:push git:gacp git:push git:push:force git:push:set:upstream git:pull git:rebase git:rebase:abort git:rebase:continue git:rebase:skip git:rebase:interactive git:merge:main git:main:merge:branch git:clone git:custom:source git:auth:login git:pr:create git:pr:approve git:remote:add git:remote:set-url git:remote:list git:remote:remove git:worktree:list git:worktree:add git:worktree:add:new git:worktree:remove git:worktree:prune git:worktree:lock git:worktree:unlock git:worktree:cd"
+    printf '%s\n' "git:status git:info git:branch git:branch:new git:branch:create git:branch:new:feature git:branch:new:bugfix git:branch:new:description git:branch:describe git:branch:delete git:branch:clean:merged git:add git:add:all git:diff git:diff:vim git:log:oneline git:log:graph git:fetch git:fetch:prune git:stash:pop git:stash:clear git:stash:drop git:checkout git:switch git:switch:pull git:commit git:commit:staged git:commit:all git:commit:amend git:commit:amend:all git:commit:push git:gacp git:push git:push:force git:push:set:upstream git:pull git:rebase git:rebase:abort git:rebase:continue git:rebase:skip git:rebase:interactive git:merge:main git:main:merge:branch git:clone git:auth:login git:pr:create git:pr:approve git:remote:add git:remote:set-url git:remote:list git:remote:remove git:worktree:list git:worktree:add git:worktree:add:new git:worktree:remove git:worktree:prune git:worktree:lock git:worktree:unlock git:worktree:cd"
     return 0
 }
 
@@ -1653,10 +1632,6 @@ function caddie_git_help() {
     caddie cli:usage "caddie git:<command>"
     caddie cli:blank
 
-    caddie cli:title "Profile integration:"
-    caddie cli:indent "custom:source         Load ~/.bash_profile-caddie-custom and ~/.bashrc-caddie-custom (if present)"
-    caddie cli:blank
-    
     caddie cli:title "Basics:"
     caddie cli:indent "status                 Show git status"
     caddie cli:indent "info                   Show repository summary"
@@ -1760,7 +1735,6 @@ function caddie_git_help() {
     caddie cli:indent "caddie git:worktree:add ../repo-worktree feature/analytics"
     caddie cli:indent "caddie git:worktree:add:new ../repo-worktree feature/analytics"
     caddie cli:indent "caddie git:worktree:list"
-    caddie cli:indent "caddie git:custom:source"
     caddie cli:blank
     caddie cli:title "Setup GitHub Integration:"
     caddie cli:indent "caddie github:account:set <account>  Set GitHub account"
@@ -1777,8 +1751,6 @@ function caddie_git_description() {
 }
 
 # Export functions for external use
-export -f caddie_source_custom_files
-export -f caddie_git_custom_source
 export -f caddie_git_status
 export -f caddie_git_branch
 export -f caddie_git_branch_candidates

--- a/modules/dot_caddie_js
+++ b/modules/dot_caddie_js
@@ -6,6 +6,19 @@
 # Source CLI module for formatting
 source "$HOME/.caddie_modules/.caddie_cli"
 
+# Load NVM and honor .nvmrc (each agent:exec subprocess starts fresh)
+function _caddie_js_ensure_nvm() {
+    export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+    if [ -s "${NVM_DIR}/nvm.sh" ]; then
+        # shellcheck disable=SC1091
+        . "${NVM_DIR}/nvm.sh"
+    fi
+    if [ -f ".nvmrc" ] && command -v nvm >/dev/null 2>&1; then
+        nvm use >/dev/null 2>&1 || return 0
+    fi
+    return 0
+}
+
 # Register help information
 function caddie_js_description() {
     # caddie:lint:disable
@@ -225,7 +238,8 @@ function caddie_js_project_install() {
     fi
     
     caddie cli:title "Installing project dependencies..."
-    
+    _caddie_js_ensure_nvm
+
     if [ -f "yarn.lock" ]; then
         yarn install
     elif [ -f "pnpm-lock.yaml" ]; then
@@ -251,7 +265,8 @@ function caddie_js_project_update() {
     fi
     
     caddie cli:title "Updating project dependencies..."
-    
+    _caddie_js_ensure_nvm
+
     if [ -f "yarn.lock" ]; then
         yarn upgrade
     elif [ -f "pnpm-lock.yaml" ]; then
@@ -276,17 +291,22 @@ function caddie_js_project_test() {
         return 1
     fi
     
+    local status=0
+
+    _caddie_js_ensure_nvm
     caddie cli:title "Running Node.js tests..."
-    
+
     if [ -f "package.json" ] && grep -q '"test"' package.json; then
         npm test
+        status=$?
     elif [ -d "tests" ]; then
         npx jest
+        status=$?
     else
         caddie cli:warning "No tests found. Create tests in the 'tests' directory"
         return 1
     fi
-    return 0
+    return "$status"
 }
 
 # Function to build Node.js project
@@ -296,21 +316,26 @@ function caddie_js_project_build() {
         return 1
     fi
     
+    local status=0
+
+    _caddie_js_ensure_nvm
     caddie cli:title "Building Node.js project..."
-    
-    # Install dependencies
-    caddie_js_project_install
-    
-    # Run tests
+
+    caddie_js_project_install || return $?
+
     if [ -d "tests" ]; then
-        caddie_js_project_test
+        caddie_js_project_test || return $?
     fi
-    
-    # Run linting
+
     if grep -q '"lint"' package.json; then
         npm run lint
+        status=$?
+        if [ "$status" -ne 0 ]; then
+            caddie cli:x "Lint failed"
+            return "$status"
+        fi
     fi
-    
+
     caddie cli:check "Node.js project built successfully"
     return 0
 }
@@ -322,20 +347,25 @@ function caddie_js_project_serve() {
         return 1
     fi
     
+    local status=0
+
+    _caddie_js_ensure_nvm
     caddie cli:title "Starting Node.js application..."
-    
-    # Check for start script
+
     if grep -q '"start"' package.json; then
         npm start
+        status=$?
     elif grep -q '"dev"' package.json; then
         npm run dev
+        status=$?
     elif [ -f "src/index.js" ]; then
         node src/index.js
+        status=$?
     else
         caddie cli:warning "No start script found. Add 'start' or 'dev' script to package.json"
         return 1
     fi
-    return 0
+    return "$status"
 }
 
 # Function to install npm package
@@ -418,29 +448,45 @@ function caddie_js_package_outdated() {
 
 # Function to audit package security
 function caddie_js_package_audit() {
+    local status=0
+
+    _caddie_js_ensure_nvm
     caddie cli:title "Auditing package security..."
     npm audit
-    return 0
+    status=$?
+    return "$status"
 }
 
 # Function to run npm script
 function caddie_js_package_run() {
     local script="$1"
-    
+    local status=0
+
     if [ -z "$script" ]; then
         caddie cli:red "Error: Please provide a script name"
-        caddie cli:usage "caddie js:package:run <script>"
+        caddie cli:usage "caddie js:package:run <script> [-- npm-args...]"
         return 1
     fi
-    
+
     if [ ! -f "package.json" ]; then
         caddie cli:red "Error: Not in a Node.js project directory (package.json not found)"
         return 1
     fi
-    
+
+    _caddie_js_ensure_nvm
+    shift || true
+    if [ "${1:-}" = "--" ]; then
+        shift
+    fi
+
     caddie cli:title "Running script: $script"
-    npm run "$script"
-    return 0
+    if [ "$#" -gt 0 ]; then
+        npm run "$script" -- "$@"
+    else
+        npm run "$script"
+    fi
+    status=$?
+    return "$status"
 }
 
 # Function to publish npm package
@@ -558,20 +604,25 @@ function caddie_js_framework_serve() {
         return 1
     fi
     
+    local status=0
+
+    _caddie_js_ensure_nvm
     caddie cli:title "Starting framework application..."
-    
-    # Check for common framework scripts
+
     if grep -q '"dev"' package.json; then
         npm run dev
+        status=$?
     elif grep -q '"start"' package.json; then
         npm start
+        status=$?
     elif grep -q '"serve"' package.json; then
         npm run serve
+        status=$?
     else
         caddie cli:warning "No development script found. Check package.json for available scripts"
         return 1
     fi
-    return 0
+    return "$status"
 }
 
 # Function to build framework application
@@ -581,16 +632,19 @@ function caddie_js_framework_build() {
         return 1
     fi
     
+    local status=0
+
+    _caddie_js_ensure_nvm
     caddie cli:title "Building framework application..."
-    
-    # Check for build script
+
     if grep -q '"build"' package.json; then
         npm run build
+        status=$?
     else
         caddie cli:warning "No build script found. Add 'build' script to package.json"
         return 1
     fi
-    return 0
+    return "$status"
 }
 
 function caddie_js_info() {
@@ -671,7 +725,7 @@ function caddie_js_help() {
     caddie cli:indent "package:update           - Update packages"
     caddie cli:indent "package:outdated         - Check for outdated packages"
     caddie cli:indent "package:audit            - Security audit"
-    caddie cli:indent "package:run <script>     - Run npm script"
+    caddie cli:indent "package:run <script>     - Run npm script (optional args after --)"
     caddie cli:indent "package:publish          - Publish package to npm"
     caddie cli:blank
     caddie cli:title "Framework Support:"

--- a/modules/dot_caddie_js
+++ b/modules/dot_caddie_js
@@ -688,6 +688,13 @@ function caddie_js_help() {
     return 0
 }
 
+function caddie_js_commands() {
+    # caddie:lint:disable
+    printf '%s\n' 'js:info js:setup js:install js:use js:list js:version js:help js:project:init js:project:install js:project:update js:project:test js:project:build js:project:serve js:package:install js:package:uninstall js:package:list js:package:update js:package:outdated js:package:audit js:package:run js:package:publish js:framework:create js:framework:serve js:framework:build'
+    # caddie:lint:enable
+    return 0
+}
+
 # Export JavaScript functions
 export -f caddie_js_description
 export -f caddie_js_setup
@@ -714,3 +721,4 @@ export -f caddie_js_framework_create
 export -f caddie_js_framework_serve
 export -f caddie_js_framework_build
 export -f caddie_js_version
+export -f caddie_js_commands

--- a/modules/dot_caddie_profile
+++ b/modules/dot_caddie_profile
@@ -7,8 +7,67 @@ source "$HOME/.caddie_modules/.caddie_cli"
 
 function caddie_profile_description() {
     # caddie:lint:disable
-    printf '%s\n' 'Custom Bash profile snippets for project setup'
+    printf '%s\n' 'Bash profile sourcing and caddie-managed snippets'
     # caddie:lint:enable
+    return 0
+}
+
+function caddie_profile_source() {
+    local sourced=0
+
+    if [ -f "$HOME/.bash_profile" ]; then
+        # shellcheck disable=SC1090
+        source "$HOME/.bash_profile"
+        caddie cli:check "Sourced ~/.bash_profile"
+        sourced=1
+    else
+        caddie cli:yellow "~/.bash_profile not found (skipped)"
+    fi
+
+    if [ -f "$HOME/.bashrc" ]; then
+        # shellcheck disable=SC1090
+        source "$HOME/.bashrc"
+        caddie cli:check "Sourced ~/.bashrc"
+        sourced=1
+    else
+        caddie cli:yellow "~/.bashrc not found (skipped)"
+    fi
+
+    if [ "$sourced" != "1" ]; then
+        caddie cli:red "Error: No standard profile files found to source"
+        return 1
+    fi
+
+    return 0
+}
+
+function caddie_profile_custom_source() {
+    local sourced=0
+
+    if [ -f "$HOME/.bash_profile-caddie-custom" ]; then
+        # shellcheck disable=SC1090
+        source "$HOME/.bash_profile-caddie-custom"
+        caddie cli:check "Sourced ~/.bash_profile-caddie-custom"
+        sourced=1
+    else
+        caddie cli:yellow "~/.bash_profile-caddie-custom not found (skipped)"
+    fi
+
+    if [ -f "$HOME/.bashrc-caddie-custom" ]; then
+        # shellcheck disable=SC1090
+        source "$HOME/.bashrc-caddie-custom"
+        caddie cli:check "Sourced ~/.bashrc-caddie-custom"
+        sourced=1
+    else
+        caddie cli:yellow "~/.bashrc-caddie-custom not found (skipped)"
+    fi
+
+    if [ "$sourced" != "1" ]; then
+        caddie cli:red "Error: No caddie custom profile files found to source"
+        caddie cli:thought "Add snippets with caddie path:add or caddie profile:add-line"
+        return 1
+    fi
+
     return 0
 }
 
@@ -40,7 +99,7 @@ function _caddie_profile_resolve_file() {
 function _caddie_profile_print_next_steps() {
     caddie cli:blank
     caddie cli:title "Next steps:"
-    caddie cli:indent "caddie git:custom:source"
+    caddie cli:indent "caddie profile:custom:source"
     caddie cli:thought "Or open a new terminal"
     return 0
 }
@@ -219,20 +278,27 @@ function caddie_profile_info() {
     caddie cli:indent "bashrc-caddie-custom:    ~/.bashrc-caddie-custom"
     caddie cli:indent "bash-profile:            ~/.bash_profile (explicit only)"
     caddie cli:blank
-    caddie cli:thought "Load custom snippets: caddie git:custom:source"
+    caddie cli:thought "Load standard profiles: caddie profile:source"
+    caddie cli:thought "Load caddie snippets: caddie profile:custom:source"
     return 0
 }
 
 function caddie_profile_commands() {
-    printf '%s\n' 'profile:add-line profile:add-line:bashrc profile:info profile:help path:add path:add:bashrc path:add:profile'
+    printf '%s\n' 'profile:source profile:custom:source profile:add-line profile:add-line:bashrc profile:info profile:help path:add path:add:bashrc path:add:profile'
     return 0
 }
 
 function caddie_profile_help() {
     caddie cli:title "Profile Commands"
     caddie cli:blank
+    caddie cli:usage "caddie profile:source"
+    caddie cli:usage "caddie profile:custom:source"
     caddie cli:usage "caddie path:add <path> [--profile caddie-custom]"
     caddie cli:usage "caddie profile:add-line <line> [--profile caddie-custom]"
+    caddie cli:blank
+    caddie cli:title "Load profiles:"
+    caddie cli:indent "source                   Source ~/.bash_profile and ~/.bashrc (if present)"
+    caddie cli:indent "custom:source            Source ~/.bash_profile-caddie-custom and ~/.bashrc-caddie-custom"
     caddie cli:blank
     caddie cli:title "PATH management:"
     caddie cli:indent "path:add <path> [--profile name]  Append export PATH=\"<path>:\$PATH\" (default: caddie-custom)"
@@ -255,12 +321,14 @@ function caddie_profile_help() {
     caddie cli:indent "caddie path:add \"\$(brew --prefix postgresql@16)/bin\" --profile caddie-custom"
     caddie cli:indent "caddie path:add:bashrc /opt/local/bin"
     caddie cli:indent "caddie profile:add-line 'export EDITOR=vim'"
-    caddie cli:indent "caddie git:custom:source"
+    caddie cli:indent "caddie profile:custom:source"
     caddie cli:blank
     return 0
 }
 
 export -f caddie_profile_description
+export -f caddie_profile_source
+export -f caddie_profile_custom_source
 export -f caddie_path_add
 export -f caddie_path_add_bashrc
 export -f caddie_path_add_profile

--- a/modules/dot_caddie_profile
+++ b/modules/dot_caddie_profile
@@ -16,6 +16,7 @@ function caddie_profile_source() {
     local sourced=0
 
     if [ -f "$HOME/.bash_profile" ]; then
+        unset CADDIE_CLI_LOADED
         # shellcheck disable=SC1090
         source "$HOME/.bash_profile"
         caddie cli:check "Sourced ~/.bash_profile"
@@ -99,8 +100,8 @@ function _caddie_profile_resolve_file() {
 function _caddie_profile_print_next_steps() {
     caddie cli:blank
     caddie cli:title "Next steps:"
-    caddie cli:indent "caddie profile:custom:source"
-    caddie cli:thought "Or open a new terminal"
+    caddie cli:indent "Open a new terminal (custom snippets load from ~/.bash_profile)"
+    caddie cli:thought "Apply now in this shell: caddie profile:custom:source"
     return 0
 }
 

--- a/modules/dot_caddie_profile
+++ b/modules/dot_caddie_profile
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+
+# Caddie.sh - Custom Bash profile management
+# Append idempotent lines to caddie-managed profile snippets (not ~/.zshrc).
+
+source "$HOME/.caddie_modules/.caddie_cli"
+
+function caddie_profile_description() {
+    # caddie:lint:disable
+    printf '%s\n' 'Custom Bash profile snippets for project setup'
+    # caddie:lint:enable
+    return 0
+}
+
+function _caddie_profile_resolve_file() {
+    local profile="$1"
+    local profile_file=""
+
+    case "$profile" in
+        caddie-custom|bash-profile-caddie-custom)
+            profile_file="$HOME/.bash_profile-caddie-custom"
+            ;;
+        bashrc-caddie-custom)
+            profile_file="$HOME/.bashrc-caddie-custom"
+            ;;
+        bash-profile)
+            profile_file="$HOME/.bash_profile"
+            ;;
+        *)
+            caddie cli:red "Error: Unknown profile '$profile'"
+            caddie cli:usage "Supported profiles: caddie-custom, bashrc-caddie-custom, bash-profile"
+            return 1
+            ;;
+    esac
+
+    printf '%s\n' "$profile_file"
+    return 0
+}
+
+function _caddie_profile_print_next_steps() {
+    caddie cli:blank
+    caddie cli:title "Next steps:"
+    caddie cli:indent "caddie git:custom:source"
+    caddie cli:thought "Or open a new terminal"
+    return 0
+}
+
+function _caddie_profile_append_line() {
+    local profile="$1"
+    local line="$2"
+    local path_hint="${3:-}"
+    local profile_file=""
+    local created=0
+
+    profile_file="$(_caddie_profile_resolve_file "$profile")" || return 1
+
+    if [ ! -f "$profile_file" ]; then
+        {
+            printf '%s\n' '# Caddie custom profile (managed by caddie path:add / caddie profile:add-line)'
+            printf '%s\n' ''
+        } > "$profile_file"
+        created=1
+    fi
+
+    if [ -n "$path_hint" ]; then
+        if grep -Fq "$path_hint" "$profile_file" 2>/dev/null; then
+            caddie cli:yellow "Path already present in $profile_file"
+            caddie cli:indent "$path_hint"
+            return 0
+        fi
+    elif grep -Fx "$line" "$profile_file" 2>/dev/null; then
+        caddie cli:yellow "Line already present in $profile_file"
+        caddie cli:indent "$line"
+        return 0
+    fi
+
+    printf '%s\n' "$line" >> "$profile_file"
+
+    if [ "$created" = "1" ]; then
+        caddie cli:check "Created $profile_file"
+    fi
+    caddie cli:check "Added to $profile_file"
+    caddie cli:indent "$line"
+    _caddie_profile_print_next_steps
+    return 0
+}
+
+function caddie_path_add() {
+    local profile="caddie-custom"
+    local path=""
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --profile)
+                if [ -z "${2:-}" ]; then
+                    caddie cli:red "Error: --profile requires a value"
+                    caddie cli:usage "caddie path:add <path> [--profile caddie-custom]"
+                    return 1
+                fi
+                profile="$2"
+                shift 2
+                ;;
+            --profile=*)
+                profile="${1#--profile=}"
+                shift
+                ;;
+            *)
+                if [ -n "$path" ]; then
+                    caddie cli:red "Error: Unexpected argument '$1'"
+                    caddie cli:usage "caddie path:add <path> [--profile caddie-custom]"
+                    return 1
+                fi
+                path="$1"
+                shift
+                ;;
+        esac
+    done
+
+    if [ -z "$path" ]; then
+        caddie cli:red "Error: Please provide a path"
+        caddie cli:usage "caddie path:add <path> [--profile caddie-custom]"
+        caddie cli:indent "Example: caddie path:add \"\$(brew --prefix postgresql@16)/bin\" --profile caddie-custom"
+        return 1
+    fi
+
+    local line="export PATH=\"${path}:\$PATH\""
+    _caddie_profile_append_line "$profile" "$line" "$path"
+    return $?
+}
+
+function caddie_path_add_bashrc() {
+    local path="$1"
+
+    if [ -z "$path" ]; then
+        caddie cli:red "Error: Please provide a path"
+        caddie cli:usage "caddie path:add:bashrc <path>"
+        return 1
+    fi
+
+    local line="export PATH=\"${path}:\$PATH\""
+    _caddie_profile_append_line "bashrc-caddie-custom" "$line" "$path"
+    return $?
+}
+
+function caddie_path_add_profile() {
+    local profile="$1"
+    local path="$2"
+
+    if [ -z "$profile" ] || [ -z "$path" ]; then
+        caddie cli:red "Error: Profile name and path are required"
+        caddie cli:usage "caddie path:add:profile <profile> <path>"
+        caddie cli:indent "Profiles: caddie-custom, bashrc-caddie-custom, bash-profile"
+        return 1
+    fi
+
+    local line="export PATH=\"${path}:\$PATH\""
+    _caddie_profile_append_line "$profile" "$line" "$path"
+    return $?
+}
+
+function caddie_profile_add_line() {
+    local profile="caddie-custom"
+    local line=""
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --profile)
+                if [ -z "${2:-}" ]; then
+                    caddie cli:red "Error: --profile requires a value"
+                    caddie cli:usage "caddie profile:add-line <line> [--profile caddie-custom]"
+                    return 1
+                fi
+                profile="$2"
+                shift 2
+                ;;
+            --profile=*)
+                profile="${1#--profile=}"
+                shift
+                ;;
+            *)
+                if [ -n "$line" ]; then
+                    caddie cli:red "Error: Unexpected argument '$1'"
+                    caddie cli:usage "caddie profile:add-line <line> [--profile caddie-custom]"
+                    return 1
+                fi
+                line="$1"
+                shift
+                ;;
+        esac
+    done
+
+    if [ -z "$line" ]; then
+        caddie cli:red "Error: Please provide a line to append"
+        caddie cli:usage "caddie profile:add-line <line> [--profile caddie-custom]"
+        return 1
+    fi
+
+    _caddie_profile_append_line "$profile" "$line" ""
+    return $?
+}
+
+function caddie_profile_add_line_bashrc() {
+    local line="$1"
+
+    if [ -z "$line" ]; then
+        caddie cli:red "Error: Please provide a line to append"
+        caddie cli:usage "caddie profile:add-line:bashrc <line>"
+        return 1
+    fi
+
+    _caddie_profile_append_line "bashrc-caddie-custom" "$line" ""
+    return $?
+}
+
+function caddie_profile_info() {
+    caddie cli:title "Profile Targets"
+    caddie cli:blank
+    caddie cli:indent "caddie-custom (default): ~/.bash_profile-caddie-custom"
+    caddie cli:indent "bashrc-caddie-custom:    ~/.bashrc-caddie-custom"
+    caddie cli:indent "bash-profile:            ~/.bash_profile (explicit only)"
+    caddie cli:blank
+    caddie cli:thought "Load custom snippets: caddie git:custom:source"
+    return 0
+}
+
+function caddie_profile_commands() {
+    printf '%s\n' 'profile:add-line profile:add-line:bashrc profile:info profile:help path:add path:add:bashrc path:add:profile'
+    return 0
+}
+
+function caddie_profile_help() {
+    caddie cli:title "Profile Commands"
+    caddie cli:blank
+    caddie cli:usage "caddie path:add <path> [--profile caddie-custom]"
+    caddie cli:usage "caddie profile:add-line <line> [--profile caddie-custom]"
+    caddie cli:blank
+    caddie cli:title "PATH management:"
+    caddie cli:indent "path:add <path> [--profile name]  Append export PATH=\"<path>:\$PATH\" (default: caddie-custom)"
+    caddie cli:indent "path:add:bashrc <path>            Same for ~/.bashrc-caddie-custom"
+    caddie cli:indent "path:add:profile <name> <path>    Append PATH entry to a named profile"
+    caddie cli:blank
+    caddie cli:title "Generic lines:"
+    caddie cli:indent "add-line <line> [--profile name]  Append any line idempotently (default: caddie-custom)"
+    caddie cli:indent "add-line:bashrc <line>            Append to ~/.bashrc-caddie-custom"
+    caddie cli:blank
+    caddie cli:title "Profiles:"
+    caddie cli:indent "caddie-custom            ~/.bash_profile-caddie-custom (default)"
+    caddie cli:indent "bashrc-caddie-custom     ~/.bashrc-caddie-custom"
+    caddie cli:indent "bash-profile             ~/.bash_profile (explicit only; not modified by default)"
+    caddie cli:blank
+    caddie cli:title "Information:"
+    caddie cli:indent "info                     Show profile target paths"
+    caddie cli:blank
+    caddie cli:title "Examples:"
+    caddie cli:indent "caddie path:add \"\$(brew --prefix postgresql@16)/bin\" --profile caddie-custom"
+    caddie cli:indent "caddie path:add:bashrc /opt/local/bin"
+    caddie cli:indent "caddie profile:add-line 'export EDITOR=vim'"
+    caddie cli:indent "caddie git:custom:source"
+    caddie cli:blank
+    return 0
+}
+
+export -f caddie_profile_description
+export -f caddie_path_add
+export -f caddie_path_add_bashrc
+export -f caddie_path_add_profile
+export -f caddie_profile_add_line
+export -f caddie_profile_add_line_bashrc
+export -f caddie_profile_info
+export -f caddie_profile_commands
+export -f caddie_profile_help
+
+# path:add is implemented here; register path completions alongside profile.
+if declare -F caddie_completion_register >/dev/null 2>&1; then
+    caddie_completion_register "path" "path:add path:add:bashrc path:add:profile"
+fi

--- a/modules/dot_caddie_skill
+++ b/modules/dot_caddie_skill
@@ -66,7 +66,7 @@ function _caddie_skill_package_dir() {
     fi
 
     caddie cli:red "Error: Caddie skill package not found"
-    caddie cli:thought "Run make install-dot from the caddie.sh repository"
+    caddie cli:thought "Run make install from the caddie.sh repository"
     return 1
 }
 
@@ -818,7 +818,7 @@ function caddie_skill_help() {
     caddie cli:title "Examples:"
     caddie cli:indent "caddie skill:install"
     caddie cli:indent "caddie skill:install:all"
-    caddie cli:indent "make install-dot && caddie reload && caddie skill:update"
+    caddie cli:indent "make install && caddie reload && caddie skill:update"
     caddie cli:indent "caddie skill:audit"
     caddie cli:blank
     return 0

--- a/modules/dot_caddie_skill
+++ b/modules/dot_caddie_skill
@@ -75,6 +75,49 @@ function _caddie_skill_registry_ensure_dir() {
     return 0
 }
 
+function _caddie_skill_normalize_install_path() {
+    local install_path="$1"
+    local parent=""
+    local base=""
+    local resolved_parent=""
+
+    parent="$(dirname "$install_path")"
+    base="$(basename "$install_path")"
+    resolved_parent="$(cd "$parent" 2>/dev/null && pwd -P)"
+
+    if [ -n "$resolved_parent" ]; then
+        printf '%s/%s' "$resolved_parent" "$base"
+        return 0
+    fi
+
+    printf '%s\n' "$install_path"
+    return 0
+}
+
+function _caddie_skill_install_id() {
+    local install_path="$1"
+    local agent="$2"
+    local scope="$3"
+    local normalized_path=""
+    local path_hash=""
+
+    if [ "$scope" != "project" ]; then
+        printf '%s\n' "${agent}-${scope}"
+        return 0
+    fi
+
+    normalized_path="$(_caddie_skill_normalize_install_path "$install_path")"
+    if command -v shasum >/dev/null 2>&1; then
+        path_hash="$(printf '%s' "$normalized_path" | shasum -a 256 2>/dev/null | awk '{print $1}' | cut -c1-12)"
+    fi
+    if [ -z "$path_hash" ]; then
+        path_hash="$(printf '%s' "$normalized_path" | cksum 2>/dev/null | awk '{print $1}')"
+    fi
+
+    printf '%s\n' "${agent}-project-${path_hash}"
+    return 0
+}
+
 function _caddie_skill_registry_write_header() {
     local canonical="$1"
     local version="$2"
@@ -110,6 +153,54 @@ function _caddie_skill_registry_write_header() {
     return 0
 }
 
+function _caddie_skill_registry_sync_install_versions() {
+    local version="$1"
+    local synced_at="$2"
+    local tmp_file=""
+    local line=""
+    local existing_id=""
+    local existing_path=""
+    local existing_agent=""
+    local existing_scope=""
+    local existing_installed_at=""
+
+    if [ ! -f "$CADDIE_SKILL_REGISTRY_FILE" ]; then
+        return 0
+    fi
+
+    tmp_file="$(mktemp "${CADDIE_SKILL_REGISTRY_FILE}.XXXXXX")"
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+            install\|* )
+                existing_id=""
+                existing_path=""
+                existing_agent=""
+                existing_scope=""
+                existing_installed_at=""
+                IFS='|' read -r _prefix existing_id existing_path existing_agent existing_scope _old_version existing_installed_at <<< "$line"
+                printf '%s\n' "install|${existing_id}|${existing_path}|${existing_agent}|${existing_scope}|${version}|${synced_at}" >> "$tmp_file"
+                ;;
+            * )
+                printf '%s\n' "$line" >> "$tmp_file"
+                ;;
+        esac
+    done < "$CADDIE_SKILL_REGISTRY_FILE"
+
+    mv "$tmp_file" "$CADDIE_SKILL_REGISTRY_FILE"
+    return 0
+}
+
+function _caddie_skill_registry_write_header_and_sync() {
+    local canonical="$1"
+    local version="$2"
+    local updated_at="$3"
+
+    _caddie_skill_registry_write_header "$canonical" "$version" "$updated_at" || return 1
+    _caddie_skill_registry_sync_install_versions "$version" "$updated_at" || return 1
+    return 0
+}
+
 function _caddie_skill_registry_upsert_install() {
     local install_id="$1"
     local install_path="$2"
@@ -120,27 +211,54 @@ function _caddie_skill_registry_upsert_install() {
     local canonical=""
     local registry_version=""
     local updated_at=""
+    local normalized_path=""
     local tmp_file=""
     local line=""
     local found=0
+    local existing_id=""
+    local existing_path=""
+    local existing_agent=""
+    local existing_scope=""
+    local existing_version=""
+    local existing_installed_at=""
+    local existing_normalized=""
 
     canonical="$(_caddie_skill_canonical_dir)"
     registry_version="$(_caddie_skill_version)"
     updated_at="$(_caddie_skill_timestamp)"
+    normalized_path="$(_caddie_skill_normalize_install_path "$install_path")"
+    install_path="$normalized_path"
 
     _caddie_skill_registry_ensure_dir || return 1
 
     if [ ! -f "$CADDIE_SKILL_REGISTRY_FILE" ]; then
-        _caddie_skill_registry_write_header "$canonical" "$registry_version" "$updated_at" || return 1
+        _caddie_skill_registry_write_header_and_sync "$canonical" "$registry_version" "$updated_at" || return 1
     fi
 
     tmp_file="$(mktemp "${CADDIE_SKILL_REGISTRY_FILE}.XXXXXX")"
 
     while IFS= read -r line || [ -n "$line" ]; do
         case "$line" in
-            install\|${install_id}\|* )
-                found=1
-                printf '%s\n' "install|${install_id}|${install_path}|${agent}|${scope}|${version}|${installed_at}" >> "$tmp_file"
+            install\|* )
+                existing_id=""
+                existing_path=""
+                existing_agent=""
+                existing_scope=""
+                existing_version=""
+                existing_installed_at=""
+                IFS='|' read -r _prefix existing_id existing_path existing_agent existing_scope existing_version existing_installed_at <<< "$line"
+                existing_normalized="$(_caddie_skill_normalize_install_path "$existing_path")"
+
+                if [ "$existing_normalized" = "$normalized_path" ]; then
+                    if [ "$found" = "1" ]; then
+                        continue
+                    fi
+                    found=1
+                    printf '%s\n' "install|${install_id}|${install_path}|${agent}|${scope}|${version}|${installed_at}" >> "$tmp_file"
+                    continue
+                fi
+
+                printf '%s\n' "$line" >> "$tmp_file"
                 ;;
             * )
                 printf '%s\n' "$line" >> "$tmp_file"
@@ -189,7 +307,7 @@ function _caddie_skill_refresh_canonical() {
     canonical_resolved="$(_caddie_skill_resolve_path "$canonical" 2>/dev/null || true)"
 
     if [ -n "$canonical_resolved" ] && [ "$package_resolved" = "$canonical_resolved" ] && [ -f "${canonical}/SKILL.md" ]; then
-        _caddie_skill_registry_write_header "$canonical" "$version" "$updated_at" || return 1
+        _caddie_skill_registry_write_header_and_sync "$canonical" "$version" "$updated_at" || return 1
         caddie cli:check "Canonical skill already installed (${version})"
         caddie cli:indent "$canonical"
         return 0
@@ -204,9 +322,66 @@ function _caddie_skill_refresh_canonical() {
         return 1
     fi
 
-    _caddie_skill_registry_write_header "$canonical" "$version" "$updated_at" || return 1
+    _caddie_skill_registry_write_header_and_sync "$canonical" "$version" "$updated_at" || return 1
     caddie cli:check "Canonical skill updated (${version})"
     caddie cli:indent "$canonical"
+    return 0
+}
+
+function _caddie_skill_is_skill_directory() {
+    local path="$1"
+
+    if [ -d "$path" ] && [ ! -L "$path" ] && [ -f "${path}/SKILL.md" ]; then
+        return 0
+    fi
+
+    return 1
+}
+
+function _caddie_skill_registry_has_install_path() {
+    local install_path="$1"
+    local normalized_path=""
+    local line=""
+    local existing_path=""
+    local existing_normalized=""
+
+    if [ ! -f "$CADDIE_SKILL_REGISTRY_FILE" ]; then
+        return 1
+    fi
+
+    normalized_path="$(_caddie_skill_normalize_install_path "$install_path")"
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+            install\|* )
+                existing_path=""
+                IFS='|' read -r _prefix _install_id existing_path _agent _scope _version _installed_at <<< "$line"
+                existing_normalized="$(_caddie_skill_normalize_install_path "$existing_path")"
+                if [ "$existing_normalized" = "$normalized_path" ]; then
+                    return 0
+                fi
+                ;;
+        esac
+    done < "$CADDIE_SKILL_REGISTRY_FILE"
+
+    return 1
+}
+
+function _caddie_skill_backup_directory_install() {
+    local install_path="$1"
+    local backup_path=""
+    local backup_suffix=""
+
+    backup_suffix="$(date +%Y%m%d%H%M%S 2>/dev/null || date '+%Y%m%d%H%M%S')"
+    backup_path="${install_path}.pre-caddie-link.${backup_suffix}"
+
+    if ! mv "$install_path" "$backup_path"; then
+        caddie cli:red "Error: Could not move ${install_path} to ${backup_path}"
+        return 1
+    fi
+
+    caddie cli:yellow "Backed up directory install"
+    caddie cli:indent "${backup_path}"
     return 0
 }
 
@@ -228,10 +403,10 @@ function _caddie_skill_resolve_path() {
 }
 
 function _caddie_skill_install_link() {
-    local install_id="$1"
-    local link_path="$2"
-    local agent="$3"
-    local scope="$4"
+    local link_path="$1"
+    local agent="$2"
+    local scope="$3"
+    local install_id=""
     local canonical=""
     local version=""
     local installed_at=""
@@ -239,6 +414,7 @@ function _caddie_skill_install_link() {
     local existing_target=""
     local canonical_resolved=""
 
+    install_id="$(_caddie_skill_install_id "$link_path" "$agent" "$scope")"
     canonical="$(_caddie_skill_canonical_dir)"
     version="$(_caddie_skill_version)"
     installed_at="$(_caddie_skill_timestamp)"
@@ -252,9 +428,15 @@ function _caddie_skill_install_link() {
     mkdir -p "$parent"
 
     if [ -e "$link_path" ] && [ ! -L "$link_path" ]; then
-        caddie cli:red "Error: ${link_path} exists and is not a symlink"
-        caddie cli:thought "Move it aside manually or remove it, then retry"
-        return 1
+        if _caddie_skill_is_skill_directory "$link_path"; then
+            if ! _caddie_skill_backup_directory_install "$link_path"; then
+                return 1
+            fi
+        else
+            caddie cli:red "Error: ${link_path} exists and is not a symlink"
+            caddie cli:thought "Move it aside manually or remove it, then retry"
+            return 1
+        fi
     fi
 
     canonical_resolved="$(_caddie_skill_resolve_path "$canonical")"
@@ -302,7 +484,7 @@ function caddie_skill_install_project() {
     fi
 
     link_path="$(pwd)/.cursor/skills/${CADDIE_SKILL_NAME}"
-    _caddie_skill_install_link "cursor-project" "$link_path" "cursor" "project"
+    _caddie_skill_install_link "$link_path" "cursor" "project"
     status=$?
 
     if [ "$status" -eq 0 ]; then
@@ -320,7 +502,7 @@ function caddie_skill_install_cursor() {
         return 1
     fi
 
-    _caddie_skill_install_link "cursor-user" "$link_path" "cursor" "user"
+    _caddie_skill_install_link "$link_path" "cursor" "user"
     return $?
 }
 
@@ -331,7 +513,7 @@ function caddie_skill_install_codex() {
         return 1
     fi
 
-    _caddie_skill_install_link "codex-user" "$link_path" "codex" "user"
+    _caddie_skill_install_link "$link_path" "codex" "user"
     return $?
 }
 
@@ -360,6 +542,7 @@ function caddie_skill_install_all() {
 
 function _caddie_skill_audit_install_line() {
     local line="$1"
+    local registry_version="$2"
     local current_version=""
     local canonical=""
     local canonical_resolved=""
@@ -370,6 +553,7 @@ function _caddie_skill_audit_install_line() {
     local recorded_version=""
     local installed_at=""
     local link_target=""
+    local symlink_ok=0
     local issues=0
 
     current_version="$(_caddie_skill_version)"
@@ -398,11 +582,14 @@ function _caddie_skill_audit_install_line() {
             issues=1
         else
             caddie cli:check "  Symlink OK"
+            symlink_ok=1
         fi
     fi
 
-    if [ "$recorded_version" != "$current_version" ]; then
-        caddie cli:yellow "  Version: registry ${recorded_version} ≠ caddie ${current_version} (run caddie skill:update)"
+    if [ "$symlink_ok" = "1" ] && [ -n "$registry_version" ] && [ "$registry_version" = "$current_version" ]; then
+        caddie cli:indent "  Version: ${current_version} (canonical registry)"
+    elif [ "$recorded_version" != "$current_version" ]; then
+        caddie cli:yellow "  Version: install ${recorded_version} ≠ caddie ${current_version} (run caddie skill:update)"
         issues=1
     else
         caddie cli:indent "  Version: ${current_version}"
@@ -412,9 +599,67 @@ function _caddie_skill_audit_install_line() {
     return "$issues"
 }
 
+function _caddie_skill_audit_expected_user_path() {
+    local install_path="$1"
+    local agent="$2"
+    local scope="$3"
+    local install_command="$4"
+    local canonical_resolved="$5"
+    local registry_version="$6"
+    local current_version=""
+    local link_target=""
+    local issues=0
+    local symlink_ok=0
+
+    current_version="$(_caddie_skill_version)"
+
+    if [ ! -e "$install_path" ]; then
+        return 0
+    fi
+
+    caddie cli:title "${agent} user (${install_path})"
+
+    if _caddie_skill_is_skill_directory "$install_path"; then
+        caddie cli:yellow "  Directory copy (not a symlink to canonical)"
+        caddie cli:thought "Run: ${install_command} (backs up the directory, then links to canonical)"
+        issues=1
+    elif [ ! -L "$install_path" ]; then
+        caddie cli:red "  Exists but is not a directory or symlink"
+        issues=1
+    else
+        link_target="$(_caddie_skill_resolve_path "$install_path")"
+        if [ -z "$link_target" ]; then
+            caddie cli:red "  Symlink could not be resolved"
+            issues=1
+        elif [ "$link_target" != "$canonical_resolved" ]; then
+            caddie cli:yellow "  Symlink target: ${link_target}"
+            caddie cli:yellow "  Expected:       ${canonical_resolved}"
+            issues=1
+        else
+            caddie cli:check "  Symlink OK"
+            symlink_ok=1
+        fi
+    fi
+
+    if [ "$symlink_ok" = "1" ]; then
+        if ! _caddie_skill_registry_has_install_path "$install_path"; then
+            caddie cli:yellow "  Not in registry (run ${install_command} to register)"
+            issues=1
+        elif [ -n "$registry_version" ] && [ "$registry_version" = "$current_version" ]; then
+            caddie cli:indent "  Version: ${current_version} (canonical registry)"
+        else
+            caddie cli:indent "  Version: ${current_version}"
+        fi
+    fi
+
+    caddie cli:blank
+    return "$issues"
+}
+
 function caddie_skill_audit() {
     local current_version=""
     local canonical=""
+    local canonical_resolved=""
     local registry_version=""
     local line=""
     local issues=0
@@ -438,7 +683,7 @@ function caddie_skill_audit() {
 
     registry_version="$(_caddie_skill_registry_get_field version 2>/dev/null || true)"
     if [ -n "$registry_version" ] && [ "$registry_version" != "$current_version" ]; then
-        caddie cli:yellow "Registry version ${registry_version} ≠ caddie ${current_version}"
+        caddie cli:yellow "Registry version ${registry_version} ≠ caddie ${current_version} (run caddie skill:update)"
         issues=1
     fi
 
@@ -452,7 +697,7 @@ function caddie_skill_audit() {
         while IFS= read -r line || [ -n "$line" ]; do
             case "$line" in
                 install\|* )
-                    _caddie_skill_audit_install_line "$line"
+                    _caddie_skill_audit_install_line "$line" "$registry_version"
                     install_issues=$?
                     if [ "$install_issues" -ne 0 ]; then
                         issues=1
@@ -462,13 +707,25 @@ function caddie_skill_audit() {
         done < "$CADDIE_SKILL_REGISTRY_FILE"
     fi
 
+    canonical_resolved="$(_caddie_skill_resolve_path "$canonical" 2>/dev/null || printf '%s' "$canonical")"
+
+    caddie cli:title "User skill paths"
+    _caddie_skill_audit_expected_user_path "$HOME/.cursor/skills/${CADDIE_SKILL_NAME}" "cursor" "user" "caddie skill:install:cursor" "$canonical_resolved" "$registry_version"
+    install_issues=$?
+    if [ "$install_issues" -ne 0 ]; then
+        issues=1
+    fi
+
+    _caddie_skill_audit_expected_user_path "$HOME/.codex/skills/${CADDIE_SKILL_NAME}" "codex" "user" "caddie skill:install:codex" "$canonical_resolved" "$registry_version"
+    install_issues=$?
+    if [ "$install_issues" -ne 0 ]; then
+        issues=1
+    fi
+
     caddie cli:title "Discovered symlinks (not in registry)"
     local discovered=0
     local search_dir=""
     local link_path=""
-    local canonical_resolved=""
-
-    canonical_resolved="$(_caddie_skill_resolve_path "$canonical" 2>/dev/null || printf '%s' "$canonical")"
 
     for search_dir in "$HOME/.cursor/skills" "$HOME/.codex/skills"; do
         if [ ! -d "$search_dir" ]; then
@@ -479,7 +736,7 @@ function caddie_skill_audit() {
                 local target=""
                 target="$(_caddie_skill_resolve_path "$link_path")"
                 if [ "$target" = "$canonical_resolved" ]; then
-                    if [ ! -f "$CADDIE_SKILL_REGISTRY_FILE" ] || ! grep -Fq "$link_path" "$CADDIE_SKILL_REGISTRY_FILE" 2>/dev/null; then
+                    if ! _caddie_skill_registry_has_install_path "$link_path"; then
                         caddie cli:indent "$link_path → canonical (unregistered)"
                         discovered=1
                     fi
@@ -546,7 +803,7 @@ function caddie_skill_help() {
     caddie cli:indent "install                  Link .cursor/skills/caddie in current directory (default)"
     caddie cli:indent "install:project          Same as install"
     caddie cli:indent "install:cursor           Link ~/.cursor/skills/caddie"
-    caddie cli:indent "install:codex            Link ~/.codex/skills/caddie"
+    caddie cli:indent "install:codex            Link ~/.codex/skills/caddie (backs up an existing skill directory)"
     caddie cli:indent "install:all              User cursor + codex installs"
     caddie cli:blank
     caddie cli:title "Maintenance:"

--- a/modules/dot_caddie_skill
+++ b/modules/dot_caddie_skill
@@ -1,0 +1,580 @@
+#!/usr/bin/env bash
+
+# Caddie.sh - Agent skill install and audit (canonical + symlinks)
+
+source "$HOME/.caddie_modules/.caddie_cli"
+
+CADDIE_SKILL_NAME="caddie"
+CADDIE_SKILL_REGISTRY_FILE="${CADDIE_SKILL_REGISTRY_FILE:-$HOME/.caddie_data/skill-installs.registry}"
+
+function caddie_skill_description() {
+    # caddie:lint:disable
+    printf '%s\n' 'Install and audit the caddie agent skill (canonical + symlinks)'
+    # caddie:lint:enable
+    return 0
+}
+
+function _caddie_skill_version() {
+    local version="${CADDIE_SH_VERSION:-}"
+
+    if [ -z "$version" ] && [ -f "$HOME/.caddie_version" ]; then
+        # shellcheck disable=SC1090
+        source "$HOME/.caddie_version"
+        version="${CADDIE_SH_VERSION:-}"
+    fi
+
+    if [ -z "$version" ]; then
+        version="unknown"
+    fi
+
+    printf '%s\n' "$version"
+    return 0
+}
+
+function _caddie_skill_canonical_dir() {
+    local modules_dir="${CADDIE_MODULES_DIR:-$HOME/.caddie_modules}"
+    printf '%s\n' "${modules_dir}/skills/${CADDIE_SKILL_NAME}"
+    return 0
+}
+
+function _caddie_skill_timestamp() {
+    date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ'
+    return 0
+}
+
+function _caddie_skill_package_dir() {
+    local modules_dir="${CADDIE_MODULES_DIR:-$HOME/.caddie_modules}"
+    local candidate=""
+
+    if [ -f "./skills/${CADDIE_SKILL_NAME}/SKILL.md" ]; then
+        (cd "./skills/${CADDIE_SKILL_NAME}" && pwd)
+        return 0
+    fi
+
+    candidate="${modules_dir}/skills/${CADDIE_SKILL_NAME}"
+    if [ -f "${candidate}/SKILL.md" ]; then
+        printf '%s\n' "$candidate"
+        return 0
+    fi
+
+    if [ -n "${CADDIE_HOME:-}" ]; then
+        candidate="${CADDIE_HOME}/skills/${CADDIE_SKILL_NAME}"
+        if [ -f "${candidate}/SKILL.md" ]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    fi
+
+    caddie cli:red "Error: Caddie skill package not found"
+    caddie cli:thought "Run make install-dot from the caddie.sh repository"
+    return 1
+}
+
+function _caddie_skill_registry_ensure_dir() {
+    mkdir -p "$(dirname "$CADDIE_SKILL_REGISTRY_FILE")"
+    return 0
+}
+
+function _caddie_skill_registry_write_header() {
+    local canonical="$1"
+    local version="$2"
+    local updated_at="$3"
+    local tmp_file=""
+    local line=""
+
+    _caddie_skill_registry_ensure_dir || return 1
+    tmp_file="$(mktemp "${CADDIE_SKILL_REGISTRY_FILE}.XXXXXX")"
+
+    {
+        printf '%s\n' '# Caddie skill install registry (managed by caddie skill:*)'
+        printf '%s\n' "canonical_path=${canonical}"
+        printf '%s\n' "version=${version}"
+        printf '%s\n' "updated_at=${updated_at}"
+        printf '%s\n' ''
+    } > "$tmp_file"
+
+    if [ -f "$CADDIE_SKILL_REGISTRY_FILE" ]; then
+        while IFS= read -r line || [ -n "$line" ]; do
+            case "$line" in
+                \#*|canonical_path=*|version=*|updated_at=*|'' )
+                    continue
+                    ;;
+                install\|* )
+                    printf '%s\n' "$line" >> "$tmp_file"
+                    ;;
+            esac
+        done < "$CADDIE_SKILL_REGISTRY_FILE"
+    fi
+
+    mv "$tmp_file" "$CADDIE_SKILL_REGISTRY_FILE"
+    return 0
+}
+
+function _caddie_skill_registry_upsert_install() {
+    local install_id="$1"
+    local install_path="$2"
+    local agent="$3"
+    local scope="$4"
+    local version="$5"
+    local installed_at="$6"
+    local canonical=""
+    local registry_version=""
+    local updated_at=""
+    local tmp_file=""
+    local line=""
+    local found=0
+
+    canonical="$(_caddie_skill_canonical_dir)"
+    registry_version="$(_caddie_skill_version)"
+    updated_at="$(_caddie_skill_timestamp)"
+
+    _caddie_skill_registry_ensure_dir || return 1
+
+    if [ ! -f "$CADDIE_SKILL_REGISTRY_FILE" ]; then
+        _caddie_skill_registry_write_header "$canonical" "$registry_version" "$updated_at" || return 1
+    fi
+
+    tmp_file="$(mktemp "${CADDIE_SKILL_REGISTRY_FILE}.XXXXXX")"
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        case "$line" in
+            install\|${install_id}\|* )
+                found=1
+                printf '%s\n' "install|${install_id}|${install_path}|${agent}|${scope}|${version}|${installed_at}" >> "$tmp_file"
+                ;;
+            * )
+                printf '%s\n' "$line" >> "$tmp_file"
+                ;;
+        esac
+    done < "$CADDIE_SKILL_REGISTRY_FILE"
+
+    if [ "$found" != "1" ]; then
+        printf '%s\n' "install|${install_id}|${install_path}|${agent}|${scope}|${version}|${installed_at}" >> "$tmp_file"
+    fi
+
+    mv "$tmp_file" "$CADDIE_SKILL_REGISTRY_FILE"
+    return 0
+}
+
+function _caddie_skill_registry_get_field() {
+    local field="$1"
+    local value=""
+
+    if [ ! -f "$CADDIE_SKILL_REGISTRY_FILE" ]; then
+        return 1
+    fi
+
+    value="$(grep -m 1 "^${field}=" "$CADDIE_SKILL_REGISTRY_FILE" 2>/dev/null | cut -d= -f2-)"
+    if [ -n "$value" ]; then
+        printf '%s\n' "$value"
+        return 0
+    fi
+
+    return 1
+}
+
+function _caddie_skill_refresh_canonical() {
+    local package_dir=""
+    local canonical=""
+    local version=""
+    local updated_at=""
+    local package_resolved=""
+    local canonical_resolved=""
+
+    package_dir="$(_caddie_skill_package_dir)" || return 1
+    canonical="$(_caddie_skill_canonical_dir)"
+    version="$(_caddie_skill_version)"
+    updated_at="$(_caddie_skill_timestamp)"
+    package_resolved="$(_caddie_skill_resolve_path "$package_dir" 2>/dev/null || printf '%s' "$package_dir")"
+    canonical_resolved="$(_caddie_skill_resolve_path "$canonical" 2>/dev/null || true)"
+
+    if [ -n "$canonical_resolved" ] && [ "$package_resolved" = "$canonical_resolved" ] && [ -f "${canonical}/SKILL.md" ]; then
+        _caddie_skill_registry_write_header "$canonical" "$version" "$updated_at" || return 1
+        caddie cli:check "Canonical skill already installed (${version})"
+        caddie cli:indent "$canonical"
+        return 0
+    fi
+
+    mkdir -p "$(dirname "$canonical")"
+    rm -rf "$canonical"
+    mkdir -p "$canonical"
+
+    if ! cp -R "${package_dir}/." "$canonical/"; then
+        caddie cli:red "Error: Failed to copy skill package to ${canonical}"
+        return 1
+    fi
+
+    _caddie_skill_registry_write_header "$canonical" "$version" "$updated_at" || return 1
+    caddie cli:check "Canonical skill updated (${version})"
+    caddie cli:indent "$canonical"
+    return 0
+}
+
+function _caddie_skill_resolve_path() {
+    local path="$1"
+    local resolved=""
+
+    if [ ! -e "$path" ]; then
+        return 1
+    fi
+
+    resolved="$(cd "$path" 2>/dev/null && pwd -P)"
+    if [ -n "$resolved" ]; then
+        printf '%s\n' "$resolved"
+        return 0
+    fi
+
+    return 1
+}
+
+function _caddie_skill_install_link() {
+    local install_id="$1"
+    local link_path="$2"
+    local agent="$3"
+    local scope="$4"
+    local canonical=""
+    local version=""
+    local installed_at=""
+    local parent=""
+    local existing_target=""
+    local canonical_resolved=""
+
+    canonical="$(_caddie_skill_canonical_dir)"
+    version="$(_caddie_skill_version)"
+    installed_at="$(_caddie_skill_timestamp)"
+    parent="$(dirname "$link_path")"
+
+    if [ ! -f "${canonical}/SKILL.md" ]; then
+        caddie cli:red "Error: Canonical skill is missing; run caddie skill:update first"
+        return 1
+    fi
+
+    mkdir -p "$parent"
+
+    if [ -e "$link_path" ] && [ ! -L "$link_path" ]; then
+        caddie cli:red "Error: ${link_path} exists and is not a symlink"
+        caddie cli:thought "Move it aside manually or remove it, then retry"
+        return 1
+    fi
+
+    canonical_resolved="$(_caddie_skill_resolve_path "$canonical")"
+
+    if [ -L "$link_path" ]; then
+        existing_target="$(_caddie_skill_resolve_path "$link_path")"
+        if [ "$existing_target" = "$canonical_resolved" ]; then
+            caddie cli:yellow "Already linked to canonical skill"
+            caddie cli:indent "$link_path"
+            _caddie_skill_registry_upsert_install "$install_id" "$link_path" "$agent" "$scope" "$version" "$installed_at"
+            return 0
+        fi
+        rm -f "$link_path"
+    elif [ -e "$link_path" ]; then
+        rm -f "$link_path"
+    fi
+
+    if ! ln -sf "$canonical_resolved" "$link_path"; then
+        caddie cli:red "Error: Failed to create symlink at ${link_path}"
+        return 1
+    fi
+
+    caddie cli:check "Linked ${link_path}"
+    caddie cli:indent "→ ${canonical_resolved}"
+    _caddie_skill_registry_upsert_install "$install_id" "$link_path" "$agent" "$scope" "$version" "$installed_at"
+    return 0
+}
+
+function caddie_skill_update() {
+    _caddie_skill_refresh_canonical
+    return $?
+}
+
+function caddie_skill_install() {
+    caddie_skill_install_project
+    return $?
+}
+
+function caddie_skill_install_project() {
+    local link_path=""
+    local status=0
+
+    if ! _caddie_skill_refresh_canonical; then
+        return 1
+    fi
+
+    link_path="$(pwd)/.cursor/skills/${CADDIE_SKILL_NAME}"
+    _caddie_skill_install_link "cursor-project" "$link_path" "cursor" "project"
+    status=$?
+
+    if [ "$status" -eq 0 ]; then
+        caddie cli:blank
+        caddie cli:thought "Project skill is local; add .cursor/skills/caddie to .gitignore if you do not commit it"
+    fi
+
+    return "$status"
+}
+
+function caddie_skill_install_cursor() {
+    local link_path="$HOME/.cursor/skills/${CADDIE_SKILL_NAME}"
+
+    if ! _caddie_skill_refresh_canonical; then
+        return 1
+    fi
+
+    _caddie_skill_install_link "cursor-user" "$link_path" "cursor" "user"
+    return $?
+}
+
+function caddie_skill_install_codex() {
+    local link_path="$HOME/.codex/skills/${CADDIE_SKILL_NAME}"
+
+    if ! _caddie_skill_refresh_canonical; then
+        return 1
+    fi
+
+    _caddie_skill_install_link "codex-user" "$link_path" "codex" "user"
+    return $?
+}
+
+function caddie_skill_install_all() {
+    local status=0
+    local overall=0
+
+    if ! _caddie_skill_refresh_canonical; then
+        return 1
+    fi
+
+    caddie_skill_install_cursor
+    status=$?
+    if [ "$status" -ne 0 ]; then
+        overall=1
+    fi
+
+    caddie_skill_install_codex
+    status=$?
+    if [ "$status" -ne 0 ]; then
+        overall=1
+    fi
+
+    return "$overall"
+}
+
+function _caddie_skill_audit_install_line() {
+    local line="$1"
+    local current_version=""
+    local canonical=""
+    local canonical_resolved=""
+    local install_id=""
+    local install_path=""
+    local agent=""
+    local scope=""
+    local recorded_version=""
+    local installed_at=""
+    local link_target=""
+    local issues=0
+
+    current_version="$(_caddie_skill_version)"
+    canonical="$(_caddie_skill_canonical_dir)"
+    canonical_resolved="$(_caddie_skill_resolve_path "$canonical" 2>/dev/null || printf '%s' "$canonical")"
+
+    IFS='|' read -r _prefix install_id install_path agent scope recorded_version installed_at <<< "$line"
+
+    caddie cli:title "${install_id} (${agent}/${scope})"
+    caddie cli:indent "path: ${install_path}"
+
+    if [ ! -e "$install_path" ]; then
+        caddie cli:red "  Missing install path"
+        issues=1
+    elif [ ! -L "$install_path" ]; then
+        caddie cli:red "  Not a symlink (expected link to canonical)"
+        issues=1
+    else
+        link_target="$(_caddie_skill_resolve_path "$install_path")"
+        if [ -z "$link_target" ]; then
+            caddie cli:red "  Symlink could not be resolved"
+            issues=1
+        elif [ "$link_target" != "$canonical_resolved" ]; then
+            caddie cli:yellow "  Symlink target: ${link_target}"
+            caddie cli:yellow "  Expected:       ${canonical_resolved}"
+            issues=1
+        else
+            caddie cli:check "  Symlink OK"
+        fi
+    fi
+
+    if [ "$recorded_version" != "$current_version" ]; then
+        caddie cli:yellow "  Version: registry ${recorded_version} ≠ caddie ${current_version} (run caddie skill:update)"
+        issues=1
+    else
+        caddie cli:indent "  Version: ${current_version}"
+    fi
+
+    caddie cli:blank
+    return "$issues"
+}
+
+function caddie_skill_audit() {
+    local current_version=""
+    local canonical=""
+    local registry_version=""
+    local line=""
+    local issues=0
+    local install_issues=0
+
+    current_version="$(_caddie_skill_version)"
+    canonical="$(_caddie_skill_canonical_dir)"
+
+    caddie cli:title "Caddie skill audit"
+    caddie cli:blank
+    caddie cli:indent "Caddie version: ${current_version}"
+    caddie cli:indent "Canonical:      ${canonical}"
+
+    if [ ! -f "${canonical}/SKILL.md" ]; then
+        caddie cli:red "Canonical skill missing SKILL.md"
+        caddie cli:thought "Run: caddie skill:update"
+        issues=1
+    else
+        caddie cli:check "Canonical skill present"
+    fi
+
+    registry_version="$(_caddie_skill_registry_get_field version 2>/dev/null || true)"
+    if [ -n "$registry_version" ] && [ "$registry_version" != "$current_version" ]; then
+        caddie cli:yellow "Registry version ${registry_version} ≠ caddie ${current_version}"
+        issues=1
+    fi
+
+    caddie cli:blank
+    caddie cli:title "Registered installs"
+
+    if [ ! -f "$CADDIE_SKILL_REGISTRY_FILE" ]; then
+        caddie cli:yellow "No registry file (run caddie skill:install)"
+        issues=1
+    else
+        while IFS= read -r line || [ -n "$line" ]; do
+            case "$line" in
+                install\|* )
+                    _caddie_skill_audit_install_line "$line"
+                    install_issues=$?
+                    if [ "$install_issues" -ne 0 ]; then
+                        issues=1
+                    fi
+                    ;;
+            esac
+        done < "$CADDIE_SKILL_REGISTRY_FILE"
+    fi
+
+    caddie cli:title "Discovered symlinks (not in registry)"
+    local discovered=0
+    local search_dir=""
+    local link_path=""
+    local canonical_resolved=""
+
+    canonical_resolved="$(_caddie_skill_resolve_path "$canonical" 2>/dev/null || printf '%s' "$canonical")"
+
+    for search_dir in "$HOME/.cursor/skills" "$HOME/.codex/skills"; do
+        if [ ! -d "$search_dir" ]; then
+            continue
+        fi
+        for link_path in "$search_dir"/*; do
+            if [ -L "$link_path" ]; then
+                local target=""
+                target="$(_caddie_skill_resolve_path "$link_path")"
+                if [ "$target" = "$canonical_resolved" ]; then
+                    if [ ! -f "$CADDIE_SKILL_REGISTRY_FILE" ] || ! grep -Fq "$link_path" "$CADDIE_SKILL_REGISTRY_FILE" 2>/dev/null; then
+                        caddie cli:indent "$link_path → canonical (unregistered)"
+                        discovered=1
+                    fi
+                fi
+            fi
+        done
+    done
+
+    if [ "$discovered" != "1" ]; then
+        caddie cli:indent "(none)"
+    fi
+
+    caddie cli:blank
+    if [ "$issues" -eq 0 ]; then
+        caddie cli:check "Skill installs are consistent with caddie ${current_version}"
+        return 0
+    fi
+
+    caddie cli:yellow "Audit found issues — run caddie skill:update and reinstall as needed"
+    return 1
+}
+
+function caddie_skill_info() {
+    local version=""
+    local canonical=""
+    local registry_version=""
+    local updated_at=""
+    local install_count=0
+
+    version="$(_caddie_skill_version)"
+    canonical="$(_caddie_skill_canonical_dir)"
+    registry_version="$(_caddie_skill_registry_get_field version 2>/dev/null || true)"
+    updated_at="$(_caddie_skill_registry_get_field updated_at 2>/dev/null || true)"
+
+    if [ -f "$CADDIE_SKILL_REGISTRY_FILE" ]; then
+        install_count="$(grep -c '^install|' "$CADDIE_SKILL_REGISTRY_FILE" 2>/dev/null || printf '0')"
+    fi
+
+    caddie cli:title "Caddie skill"
+    caddie cli:indent "caddie version: ${version}"
+    caddie cli:indent "canonical:      ${canonical}"
+    caddie cli:indent "registry:       ${CADDIE_SKILL_REGISTRY_FILE}"
+    if [ -n "$registry_version" ]; then
+        caddie cli:indent "registry version: ${registry_version}"
+    fi
+    if [ -n "$updated_at" ]; then
+        caddie cli:indent "last updated:   ${updated_at}"
+    fi
+    caddie cli:indent "installs:       ${install_count}"
+    return 0
+}
+
+function caddie_skill_commands() {
+    printf '%s\n' 'skill:install skill:install:project skill:install:cursor skill:install:codex skill:install:all skill:update skill:audit skill:info skill:help'
+    return 0
+}
+
+function caddie_skill_help() {
+    caddie cli:title "Skill Commands"
+    caddie cli:blank
+    caddie cli:usage "caddie skill:install"
+    caddie cli:blank
+    caddie cli:title "Install (symlink → canonical):"
+    caddie cli:indent "install                  Link .cursor/skills/caddie in current directory (default)"
+    caddie cli:indent "install:project          Same as install"
+    caddie cli:indent "install:cursor           Link ~/.cursor/skills/caddie"
+    caddie cli:indent "install:codex            Link ~/.codex/skills/caddie"
+    caddie cli:indent "install:all              User cursor + codex installs"
+    caddie cli:blank
+    caddie cli:title "Maintenance:"
+    caddie cli:indent "update                   Refresh canonical from installed caddie package"
+    caddie cli:indent "audit                    Check symlinks and version consistency"
+    caddie cli:indent "info                     Show canonical path and registry summary"
+    caddie cli:blank
+    caddie cli:title "Version model:"
+    caddie cli:indent "Skill version matches CADDIE_SH_VERSION (bump both on release)"
+    caddie cli:indent "Canonical: ~/.caddie_modules/skills/caddie"
+    caddie cli:blank
+    caddie cli:title "Examples:"
+    caddie cli:indent "caddie skill:install"
+    caddie cli:indent "caddie skill:install:all"
+    caddie cli:indent "make install-dot && caddie reload && caddie skill:update"
+    caddie cli:indent "caddie skill:audit"
+    caddie cli:blank
+    return 0
+}
+
+export -f caddie_skill_description
+export -f caddie_skill_update
+export -f caddie_skill_install
+export -f caddie_skill_install_project
+export -f caddie_skill_install_cursor
+export -f caddie_skill_install_codex
+export -f caddie_skill_install_all
+export -f caddie_skill_audit
+export -f caddie_skill_info
+export -f caddie_skill_commands
+export -f caddie_skill_help

--- a/skills/caddie/SKILL.md
+++ b/skills/caddie/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: caddie
 description: Use the caddie CLI to keep development commands consistent across projects. The skill is usage guidance only — never treat it as the command list. Discover commands with caddie core:module:commands or caddie module:help. In agent shells use caddie agent:exec. Prefer caddie module:command over ad-hoc npm/cargo/git when wrappers exist.
-caddie-version: "9.3.5"
+caddie-version: "9.3.7"
 ---
 
 # Caddie — command workspace
@@ -19,7 +19,9 @@ caddie <module>:<command> [args]
 3. **No nested `:help`** — `js:project:help` does not exist. Use `caddie js:help`.
 4. **No invented shortcuts** — `js:build`, `js:dev`, `js:start` are **wrong**. Use `js:project:build`, `js:project:serve`, `js:package:run <script>`.
 5. **Prefer caddie** when a listed command matches the task; **fall back explicitly** to native tools when caddie cannot load.
-6. **Agent shells** — Use **`caddie agent:exec`** for any module (JS, Rust, Python, git, …). Do not use internal install paths.
+6. **Agent shells** — Use **`caddie agent:exec`** for any module (JS, Rust, Python, git, …). Never use `~/.caddie_modules/bin/caddie-agent-exec` or other internal install paths.
+7. **Exit codes** — Treat non-zero exit from `caddie agent:exec` as command failure; do not assume success from output alone.
+8. **Node version** — Each `agent:exec` starts a fresh subprocess. Pin Node with a project **`.nvmrc`** (honored automatically), not a prior `js:use` in another invocation.
 
 ## Agent / Codex shells (all modules)
 
@@ -51,4 +53,4 @@ If `caddie agent:exec` fails, use native project commands (`npm test`, etc.) and
 
 ## Skill updates
 
-After the user upgrades caddie: `caddie skill:update`.
+After the user upgrades caddie from the caddie.sh repo: **`make install`**, `caddie reload`, then `caddie skill:update`.

--- a/skills/caddie/SKILL.md
+++ b/skills/caddie/SKILL.md
@@ -1,53 +1,54 @@
 ---
 name: caddie
-description: Guide for working in the Par Not Far caddie.sh repository. Use when modifying or reviewing caddie modules, adding a new module, updating caddie-specific Bash workflows, touching Makefile installation logic, adjusting command completion, or validating repo conventions such as `caddie cli:*` output, linting, reload, and release-note/version requirements.
-caddie-version: "9.3.4"
+description: Use the caddie CLI to keep development commands consistent across projects. The skill is usage guidance only — never treat it as the command list. Discover commands with caddie core:module:commands or caddie module:help. In agent shells use caddie agent:exec. Prefer caddie module:command over ad-hoc npm/cargo/git when wrappers exist.
+caddie-version: "9.3.5"
 ---
 
-# Caddie
+# Caddie — command workspace
 
-Treat this repository as a modular Bash system with project-specific conventions. Start by reading the local `AGENTS.md`, then inspect only the relevant module files, docs, and Makefile sections before editing.
+**This skill is not the command list.** It tells you *how* to use caddie. The CLI is authoritative — always query it before running module commands.
 
-## Core workflow
+```bash
+caddie <module>:<command> [args]
+```
 
-1. Identify the affected module or root file.
-2. Read the local guidance in `AGENTS.md` plus the specific module docs or implementation files you need.
-3. Make the smallest coherent change that fits existing naming and output conventions.
-4. Validate with repo-native commands before stopping.
+## Agent rules (read first)
 
-## Implementation rules
+1. **Skill ≠ CLI** — Do not infer commands from the skill text, completion metadata, or memory. Query the installed CLI.
+2. **Discover commands** — `caddie agent:exec core:module:commands js` or `caddie js:help` (when the shell already loads caddie).
+3. **No nested `:help`** — `js:project:help` does not exist. Use `caddie js:help`.
+4. **No invented shortcuts** — `js:build`, `js:dev`, `js:start` are **wrong**. Use `js:project:build`, `js:project:serve`, `js:package:run <script>`.
+5. **Prefer caddie** when a listed command matches the task; **fall back explicitly** to native tools when caddie cannot load.
+6. **Agent shells** — Use **`caddie agent:exec`** for any module (JS, Rust, Python, git, …). Do not use internal install paths.
 
-- Keep module files in `modules/dot_caddie_<module>`. Do not create module files at repo root.
-- Keep function names in `caddie_<module>_<command>` form and export public functions with `export -f`.
-- Source the CLI formatter in module files and use `caddie cli:*` helpers for user-facing output. Avoid raw `echo` or `printf` except for description functions or machine-readable output.
-- Prefer descriptive subcommands over flags for user-facing behaviors.
-- When a module depends on environment variables for configuration, provide `get` / `set` / `unset` commands instead of relying on direct environment-variable usage in help text.
-- For new modules, update the Makefile install flow and expose completion with `caddie_<module>_commands()` or `caddie_completion_register`. Do not edit `_caddie_completion` directly. Do not modify `dot_caddie_modules` manually.
-- If the work introduces release-visible functionality, update the version and `RELEASE_NOTES.md`. The agent skill version matches `CADDIE_SH_VERSION` — bump both together.
+## Agent / Codex shells (all modules)
 
-## Validation
+`caddie agent:exec` is **not JavaScript-only**. Pass any valid caddie command:
 
-Run the repo workflow whenever feasible:
+```bash
+caddie agent:exec core:module:commands rust
+caddie agent:exec rust:test:unit
+caddie agent:exec python:test
+caddie agent:exec git:status
+caddie agent:exec js:project:build
+```
 
-- `caddie core:lint` on changed files or the repo
-- `make install-dot`
-- `caddie reload`
-- `caddie <module>:help`
-- Targeted command checks for the changed behavior
+If `caddie agent:exec` fails, use native project commands (`npm test`, etc.) and state that caddie was unavailable.
 
-If a command cannot run in the current environment, say so explicitly and note what remains unverified.
+## JavaScript mapping (common mistakes)
 
-## Agent skill installs
+| Wrong | Right |
+|-------|-------|
+| `js:build` | `js:project:build` |
+| `js:test` | `js:project:test` |
+| `js:dev` / `js:start` | `js:project:serve` or `js:package:run <script>` |
+| `js:init` | `js:project:init` |
+| `js:add` | `js:package:install` |
 
-Users install this skill via caddie (canonical copy + symlinks):
+## Reference
 
-- `caddie skill:install` — project `.cursor/skills/caddie` in the current directory
-- `caddie skill:install:cursor` / `:codex` / `:all` — user-level agent paths
-- `caddie skill:update` — refresh canonical skill after `make install-dot`
-- `caddie skill:audit` — verify symlinks and version match installed caddie
+**`references/using-caddie.md`** — full usage guide and fallback policy.
 
-## References
+## Skill updates
 
-- Read `references/repo-guide.md` for the repo map, checklists, and high-signal rules.
-- For Codex-specific automation or review behavior, inspect the local `docs/modules/codex.md` and `modules/dot_caddie_codex`.
-- For profile and PATH setup, see `docs/modules/profile.md` and `modules/dot_caddie_profile`.
+After the user upgrades caddie: `caddie skill:update`.

--- a/skills/caddie/SKILL.md
+++ b/skills/caddie/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: caddie
+description: Guide for working in the Par Not Far caddie.sh repository. Use when modifying or reviewing caddie modules, adding a new module, updating caddie-specific Bash workflows, touching Makefile installation logic, adjusting command completion, or validating repo conventions such as `caddie cli:*` output, linting, reload, and release-note/version requirements.
+caddie-version: "9.3.4"
+---
+
+# Caddie
+
+Treat this repository as a modular Bash system with project-specific conventions. Start by reading the local `AGENTS.md`, then inspect only the relevant module files, docs, and Makefile sections before editing.
+
+## Core workflow
+
+1. Identify the affected module or root file.
+2. Read the local guidance in `AGENTS.md` plus the specific module docs or implementation files you need.
+3. Make the smallest coherent change that fits existing naming and output conventions.
+4. Validate with repo-native commands before stopping.
+
+## Implementation rules
+
+- Keep module files in `modules/dot_caddie_<module>`. Do not create module files at repo root.
+- Keep function names in `caddie_<module>_<command>` form and export public functions with `export -f`.
+- Source the CLI formatter in module files and use `caddie cli:*` helpers for user-facing output. Avoid raw `echo` or `printf` except for description functions or machine-readable output.
+- Prefer descriptive subcommands over flags for user-facing behaviors.
+- When a module depends on environment variables for configuration, provide `get` / `set` / `unset` commands instead of relying on direct environment-variable usage in help text.
+- For new modules, update the Makefile install flow and expose completion with `caddie_<module>_commands()` or `caddie_completion_register`. Do not edit `_caddie_completion` directly. Do not modify `dot_caddie_modules` manually.
+- If the work introduces release-visible functionality, update the version and `RELEASE_NOTES.md`. The agent skill version matches `CADDIE_SH_VERSION` — bump both together.
+
+## Validation
+
+Run the repo workflow whenever feasible:
+
+- `caddie core:lint` on changed files or the repo
+- `make install-dot`
+- `caddie reload`
+- `caddie <module>:help`
+- Targeted command checks for the changed behavior
+
+If a command cannot run in the current environment, say so explicitly and note what remains unverified.
+
+## Agent skill installs
+
+Users install this skill via caddie (canonical copy + symlinks):
+
+- `caddie skill:install` — project `.cursor/skills/caddie` in the current directory
+- `caddie skill:install:cursor` / `:codex` / `:all` — user-level agent paths
+- `caddie skill:update` — refresh canonical skill after `make install-dot`
+- `caddie skill:audit` — verify symlinks and version match installed caddie
+
+## References
+
+- Read `references/repo-guide.md` for the repo map, checklists, and high-signal rules.
+- For Codex-specific automation or review behavior, inspect the local `docs/modules/codex.md` and `modules/dot_caddie_codex`.
+- For profile and PATH setup, see `docs/modules/profile.md` and `modules/dot_caddie_profile`.

--- a/skills/caddie/agents/openai.yaml
+++ b/skills/caddie/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Caddie"
+  short_description: "Work safely in caddie.sh repos"
+  default_prompt: "Use $caddie to add or update caddie.sh code and follow the repository workflow."

--- a/skills/caddie/agents/openai.yaml
+++ b/skills/caddie/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Caddie"
-  short_description: "Work safely in caddie.sh repos"
-  default_prompt: "Use $caddie to add or update caddie.sh code and follow the repository workflow."
+  short_description: "Consistent dev commands via caddie modules"
+  default_prompt: "Skill is usage guidance only. Discover commands with caddie agent:exec core:module:commands <module>. Run tasks with caddie agent:exec module:command. Prefer js:project:* not js:build/js:dev. Never use internal ~/.caddie_modules paths."

--- a/skills/caddie/references/repo-guide.md
+++ b/skills/caddie/references/repo-guide.md
@@ -1,0 +1,103 @@
+# Caddie Repo Guide
+
+Use this reference when working inside the `caddie.sh` repository.
+
+## Repository map
+
+- `dot_caddie`: main entry point
+- `dot_caddie_modules`, `dot_caddie_prompt`, `dot_caddie_version`, `dot_caddie_debug`: root system files
+- `modules/dot_caddie_*`: all module implementations, including `modules/dot_caddie_core`
+- `skills/caddie/`: agent skill shipped with caddie (installed to `~/.caddie_modules/skills/caddie`)
+- `docs/modules/*.md`: per-module documentation
+- `Makefile`: install and development flow
+- `RELEASE_NOTES.md`: required companion for release/version changes
+
+## High-signal rules
+
+- Keep module files under `modules/`.
+- Name module files `dot_caddie_<module>`.
+- Keep commands in `<module>:<command>` form.
+- Keep functions in `caddie_<module>_<command>` form.
+- Export public functions with `export -f`.
+- Source `"$HOME/.caddie_modules/.caddie_cli"` in module files.
+- Use `caddie cli:*` for user-facing output.
+- Include explicit `return 0` / `return 1` statements.
+- Declare local variables explicitly and avoid shadowing.
+- Prefer human-readable subcommands over flags.
+
+## Output rules
+
+Use:
+
+- `caddie cli:red` for errors
+- `caddie cli:usage` for usage lines
+- `caddie cli:check` or `caddie cli:green` for success
+- `caddie cli:title` for section headers
+- `caddie cli:indent` for normal text
+- `printf '%s\n'` for description functions that return plain text
+
+Avoid:
+
+- raw `echo` for normal user-facing messaging
+- direct environment-variable instructions in help text when a `get` / `set` / `unset` command should exist
+
+## New module checklist
+
+1. Create `modules/dot_caddie_<module>`.
+2. Add `caddie_<module>_description`.
+3. Add `caddie_<module>_help`.
+4. Add the command functions.
+5. Export public functions.
+6. Update `Makefile` install targets so the module is copied into `~/.caddie_modules`.
+7. Add `skills/caddie/` updates when agent-facing workflow changes (same version as `dot_caddie_version`).
+8. Expose completion with `caddie_<module>_commands()` or `caddie_completion_register`.
+9. Add or update docs in `docs/modules/`.
+10. Validate with lint, install, reload, help, and targeted command checks.
+
+Do not edit `_caddie_completion` directly.
+Do not edit `dot_caddie_modules` manually.
+
+## Existing module change checklist
+
+1. Read the relevant module implementation and matching doc file.
+2. Preserve existing command names unless the user explicitly wants a rename.
+3. Update help output when commands change.
+4. Keep CLI formatting and explicit returns consistent.
+5. Re-run lint and the smallest meaningful runtime checks.
+
+## Validation commands
+
+Use the caddie-native flow:
+
+```bash
+caddie core:lint
+caddie core:lint modules/dot_caddie_<module>
+caddie core:lint:limit 5 modules/dot_caddie_<module>
+make install-dot
+caddie reload
+caddie <module>:help
+```
+
+Add targeted command execution for the change you made.
+
+## Release rule
+
+If the change is release-visible:
+
+1. Update the version number in `dot_caddie_version`.
+2. Update `skills/caddie/SKILL.md` `caddie-version` frontmatter to match.
+3. Add the matching section in `RELEASE_NOTES.md`.
+4. Ask the user which release type to use if major/minor/bugfix is not clear.
+
+After release, users run `make install-dot`, `caddie reload`, and `caddie skill:update`.
+
+## Useful local references
+
+- `AGENTS.md`: repo-specific operating instructions
+- `README.md`: project overview and architecture
+- `docs/modules/core.md`: core and lint/reload behavior
+- `docs/modules/profile.md`: profile sourcing and PATH snippets
+- `docs/modules/skill.md`: agent skill install and audit
+- `docs/modules/codex.md`: Codex CLI and review automation behavior
+
+When the task is about a specific module, prefer that module's doc file in `docs/modules/` plus its implementation in `modules/`.

--- a/skills/caddie/references/using-caddie.md
+++ b/skills/caddie/references/using-caddie.md
@@ -59,7 +59,10 @@ caddie agent:exec js:project:test
 caddie agent:exec js:project:build
 caddie agent:exec js:project:serve
 caddie agent:exec js:package:run <script>
+caddie agent:exec js:package:run typecheck -- --incremental false
 ```
+
+Pass npm script arguments after `--`. Each `agent:exec` is a new subprocess — use **`.nvmrc`** for Node version (not a separate `js:use` call). Check the exit code; failures must not be treated as success.
 
 ## When to use caddie vs direct commands
 

--- a/skills/caddie/references/using-caddie.md
+++ b/skills/caddie/references/using-caddie.md
@@ -1,0 +1,79 @@
+# Command workspace guide
+
+## Skill vs CLI
+
+| | Skill | Caddie CLI |
+|--|-------|------------|
+| Purpose | How to use caddie | Actual commands |
+| Command list | Never authoritative | Always authoritative |
+
+Query the CLI before running module commands.
+
+## Agent shells — use `caddie agent:exec`
+
+**Module-agnostic** — works for every installed module, not JavaScript only:
+
+| Module | Discover | Example run |
+|--------|----------|-------------|
+| `js` | `caddie agent:exec core:module:commands js` | `caddie agent:exec js:project:test` |
+| `rust` | `caddie agent:exec core:module:commands rust` | `caddie agent:exec rust:test:unit` |
+| `python` | `caddie agent:exec core:module:commands python` | `caddie agent:exec python:test` |
+| `git` | `caddie agent:exec core:module:commands git` | `caddie agent:exec git:status` |
+| `github` | `caddie agent:exec core:module:commands github` | `caddie agent:exec github:account:get` |
+| `core` | `caddie agent:exec core:module:commands core` | `caddie agent:exec core:lint` |
+
+Codex and similar tools often inherit a broken Bash environment. The public entry point:
+
+```bash
+caddie agent:exec <module:command> [args...]
+```
+
+`~/bin/caddie` dispatches `agent:exec` to a clean subprocess before loading caddie in the parent shell. Do **not** use internal `~/.caddie_modules/bin/` paths.
+
+`caddie core:agent:exec` is equivalent when caddie already works in the parent shell.
+
+### When the parent shell already works
+
+```bash
+caddie core:module:commands js
+caddie js:help
+caddie js:project:test
+```
+
+## Command discovery
+
+```bash
+caddie agent:exec core:module:commands js   # best in agent shells
+caddie js:help                              # when caddie loads normally
+```
+
+**Wrong:** `js:project:help`, `js:build`, `js:dev`, `js:init`.
+
+**Right:** `js:project:build`, `js:project:test`, `js:package:run build`.
+
+## JavaScript workflows
+
+```bash
+caddie agent:exec js:project:install
+caddie agent:exec js:project:test
+caddie agent:exec js:project:build
+caddie agent:exec js:project:serve
+caddie agent:exec js:package:run <script>
+```
+
+## When to use caddie vs direct commands
+
+| Use caddie | Use direct command |
+|------------|-------------------|
+| Command listed by `core:module:commands` or module help | No wrapper exists |
+| User standardized on caddie for this stack | `caddie agent:exec` fails after install is verified |
+
+Always state when you bypass caddie.
+
+## Other modules
+
+```bash
+caddie agent:exec core:module:commands git
+caddie agent:exec core:module:commands python
+caddie agent:exec git:status
+```


### PR DESCRIPTION
## Summary

Ships **caddie 9.3.0 → 9.3.7** from `release/9.3` into `main` (main is still on 9.2.0).

- **Agent execution**: `caddie agent:exec` / `~/bin/caddie` clean Bash subprocess; `core:module:commands` for discovery; usage-only agent skill
- **Skill module**: install/update/audit for Cursor and Codex (`caddie skill:*`)
- **Profile module**: custom Bash profile snippets (`path:add`, etc.) sourced at shell startup
- **JS reliability**: npm script exit codes propagate; args after `--` forwarded; `.nvmrc` honored in agent/exec paths
- **Install workflow**: `make install` pulls on `main`; docs clarify `make install` vs `make install-dot`

## Test plan

- [x] Working tree clean on `release/9.3`; version/skill at 9.3.7
- [ ] After merge: on `main`, run `make install && caddie reload && caddie skill:update`
- [ ] `caddie --version` / prompt shows 9.3.7
- [ ] `caddie agent:exec core:module:commands js` lists real `js:project:*` / `js:package:*` commands
- [ ] `caddie agent:exec js:package:run <missing>` exits non-zero
- [ ] `caddie skill:audit` / `caddie skill:update` succeed for Cursor/Codex installs